### PR TITLE
fix: added missing permission subjects to terraform provider

### DIFF
--- a/docs/resources/project_identity_specific_privilege.md
+++ b/docs/resources/project_identity_specific_privilege.md
@@ -86,7 +86,7 @@ Required:
 
 - `actions` (List of String) Describe what action an entity can take. Enum: create,edit,delete,read
 - `conditions` (Attributes) The conditions to scope permissions (see [below for nested schema](#nestedatt--permission--conditions))
-- `subject` (String) Describe what action an entity can take. Enum: role,member,groups,settings,integrations,webhooks,service-tokens,environments,tags,audit-logs,ip-allowlist,workspace,secrets,secret-rollback,secret-approval,secret-rotation,identity
+- `subject` (String) Describe what action an entity can take. Enum: role,member,groups,settings,integrations,webhooks,service-tokens,environments,tags,audit-logs,ip-allowlist,workspace,secrets,secret-rollback,secret-approval,secret-rotation,identity,certificate-authorities,certificates,certificate-templates,kms,pki-alerts,pki-collections
 
 <a id="nestedatt--permission--conditions"></a>
 ### Nested Schema for `permission.conditions`

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -75,7 +75,7 @@ resource "infisical_project_role" "biller" {
 Required:
 
 - `action` (String) Describe what action an entity can take. Enum: create,edit,delete,read
-- `subject` (String) Describe what action an entity can take. Enum: role,member,groups,settings,integrations,webhooks,service-tokens,environments,tags,audit-logs,ip-allowlist,workspace,secrets,secret-rollback,secret-approval,secret-rotation,identity
+- `subject` (String) Describe what action an entity can take. Enum: role,member,groups,settings,integrations,webhooks,service-tokens,environments,tags,audit-logs,ip-allowlist,workspace,secrets,secret-rollback,secret-approval,secret-rotation,identity,certificate-authorities,certificates,certificate-templates,kms,pki-alerts,pki-collections
 
 Optional:
 

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -18,7 +18,7 @@ import (
 var (
 	_                   resource.Resource = &projectRoleResource{}
 	PERMISSION_ACTIONS                    = []string{"create", "edit", "delete", "read"}
-	PERMISSION_SUBJECTS                   = []string{"role", "member", "groups", "settings", "integrations", "webhooks", "service-tokens", "environments", "tags", "audit-logs", "ip-allowlist", "workspace", "secrets", "secret-rollback", "secret-approval", "secret-rotation", "identity"}
+	PERMISSION_SUBJECTS                   = []string{"role", "member", "groups", "settings", "integrations", "webhooks", "service-tokens", "environments", "tags", "audit-logs", "ip-allowlist", "workspace", "secrets", "secret-rollback", "secret-approval", "secret-rotation", "identity", "certificate-authorities", "certificates", "certificate-templates", "kms", "pki-alerts", "pki-collections"}
 )
 
 // NewProjectResource is a helper function to simplify the provider implementation.


### PR DESCRIPTION
Added missing permission subjects to terraform provider. The terraform provider is now inline with our API and [permissions documentation](https://infisical.com/docs/internals/permissions).