### PR TITLE
fix(project-user-resource): tf error if membership gets removed in infisical

### DIFF
--- a/internal/client/project_user.go
+++ b/internal/client/project_user.go
@@ -72,11 +72,11 @@ func (client Client) GetProjectUserByUsername(request GetProjectUserByUserNameRe
 		Post(fmt.Sprintf("api/v1/workspace/%s/memberships/details", request.ProjectID))
 
 	if err != nil {
-		return GetProjectUserByUserNameResponse{}, fmt.Errorf("CallCreateProject: Unable to complete api request [err=%s]", err)
+		return GetProjectUserByUserNameResponse{}, fmt.Errorf("CallGetProjectUserByUsername: Unable to complete api request [err=%s]", err)
 	}
 
 	if response.IsError() {
-		return GetProjectUserByUserNameResponse{}, fmt.Errorf("CallCreateProject: Unsuccessful response. [response=%s]", response)
+		return GetProjectUserByUserNameResponse{}, fmt.Errorf("CallGetProjectUserByUsername: Unsuccessful response. [response=%s]", response)
 	}
 
 	return projectUserResponse, nil

--- a/internal/client/project_user.go
+++ b/internal/client/project_user.go
@@ -1,6 +1,9 @@
 package infisicalclient
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func (client Client) InviteUsersToProject(request InviteUsersToProjectRequest) ([]ProjectMemberships, error) {
 	var inviteUsersToProjectResponse InviteUsersToProjectResponse
@@ -76,6 +79,11 @@ func (client Client) GetProjectUserByUsername(request GetProjectUserByUserNameRe
 	}
 
 	if response.IsError() {
+
+		if response.StatusCode() == http.StatusNotFound {
+			return GetProjectUserByUserNameResponse{}, ErrNotFound
+		}
+
 		return GetProjectUserByUserNameResponse{}, fmt.Errorf("CallGetProjectUserByUsername: Unsuccessful response. [response=%s]", response)
 	}
 

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"context"
 	"fmt"
-	"strings"
 	infisical "terraform-provider-infisical/internal/client"
 	"time"
 
@@ -348,8 +347,7 @@ func (r *ProjectUserResource) Read(ctx context.Context, req resource.ReadRequest
 	})
 
 	if err != nil {
-		// If the membership isn't found for whatever reason (user left the project, etc), remove the resource so we can re-create it, and fix the state.
-		if strings.Contains(err.Error(), "Project membership not found") {
+		if err == infisical.ErrNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
This PR resolves a bug, causing TF to error out with "Project membership not found", if the membership has been removed in Infisical. This can happen if the user manually leaves the project, or if they are removed through other means, such as by an admin.

We should always assume the terraform definitions should be the true state of Infisical. So this makes sure that if the project membership isn't found in Infisical, it will be re-created as per defined in Terraform, and then the TF state will be back in sync.

> [!CAUTION]
> This PR is dependent on https://github.com/Infisical/infisical/pull/2480, which should be merged and deployed before this is released.