### PR TITLE
misc: updated project group documentation to use id

### DIFF
--- a/docs/resources/project_group.md
+++ b/docs/resources/project_group.md
@@ -35,7 +35,7 @@ resource "infisical_project" "example" {
 
 resource "infisical_project_group" "group" {
   project_id = infisical_project.example.id
-  group_slug = "my-group"
+  group_id   = "<>"
   roles = [
     {
       role_slug                   = "admin",

--- a/examples/resources/infisical_project_group/resource.tf
+++ b/examples/resources/infisical_project_group/resource.tf
@@ -20,7 +20,7 @@ resource "infisical_project" "example" {
 
 resource "infisical_project_group" "group" {
   project_id = infisical_project.example.id
-  group_slug = "my-group"
+  group_id   = "<>"
   roles = [
     {
       role_slug                   = "admin",


### PR DESCRIPTION
This PR ensures that project group documentation demonstrates using "ID" rather than slug (like in the image below)

<img width="699" alt="image" src="https://github.com/user-attachments/assets/2cfb3192-b4e4-4c0b-bbb5-c34c848fc7e1">
