### PR TITLE
fix: resolved machine identity auth check in old resources

### DIFF
--- a/internal/provider/resource/identity.go
+++ b/internal/provider/resource/identity.go
@@ -92,7 +92,7 @@ func (r *IdentityResource) Configure(_ context.Context, req resource.ConfigureRe
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity",
 			"Only Machine Identity authentication is supported for this operation",
@@ -139,7 +139,7 @@ func (r *IdentityResource) Create(ctx context.Context, req resource.CreateReques
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity role",
 			"Only Machine Identity authentication is supported for this operation",
@@ -195,7 +195,7 @@ func (r *IdentityResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity",
 			"Only Machine Identity authentication is supported for this operation",
@@ -249,7 +249,7 @@ func (r *IdentityResource) Update(ctx context.Context, req resource.UpdateReques
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity",
 			"Only Machine Identity authentication is supported for this operation",

--- a/internal/provider/resource/identity_aws_auth.go
+++ b/internal/provider/resource/identity_aws_auth.go
@@ -187,10 +187,10 @@ func updateAwsAuthTerraformStateFromApi(ctx context.Context, diagnose diag.Diagn
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityAwsAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity aws auth",
-			"Only Machine IdentityAwsAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -239,10 +239,10 @@ func (r *IdentityAwsAuthResource) Create(ctx context.Context, req resource.Creat
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityAwsAuthResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity aws auth role",
-			"Only Machine IdentityAwsAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -283,10 +283,10 @@ func (r *IdentityAwsAuthResource) Read(ctx context.Context, req resource.ReadReq
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityAwsAuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity aws auth",
-			"Only Machine IdentityAwsAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -341,10 +341,10 @@ func (r *IdentityAwsAuthResource) Update(ctx context.Context, req resource.Updat
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityAwsAuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity aws auth",
-			"Only Machine IdentityAwsAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}

--- a/internal/provider/resource/identity_azure_auth.go
+++ b/internal/provider/resource/identity_azure_auth.go
@@ -178,10 +178,10 @@ func updateAzureAuthTerraformStateByApi(ctx context.Context, diagnose diag.Diagn
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityAzureAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity azure auth",
-			"Only Machine IdentityAzureAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -227,10 +227,10 @@ func (r *IdentityAzureAuthResource) Create(ctx context.Context, req resource.Cre
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityAzureAuthResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity azure auth role",
-			"Only Machine IdentityAzureAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -271,10 +271,10 @@ func (r *IdentityAzureAuthResource) Read(ctx context.Context, req resource.ReadR
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityAzureAuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity azure auth",
-			"Only Machine IdentityAzureAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -327,10 +327,10 @@ func (r *IdentityAzureAuthResource) Update(ctx context.Context, req resource.Upd
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityAzureAuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity azure auth",
-			"Only Machine IdentityAzureAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}

--- a/internal/provider/resource/identity_gcp_auth.go
+++ b/internal/provider/resource/identity_gcp_auth.go
@@ -196,10 +196,10 @@ func updateGcpAuthStateByApi(ctx context.Context, diagnose diag.Diagnostics, pla
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityGcpAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity gcp auth",
-			"Only Machine IdentityGcpAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -249,10 +249,10 @@ func (r *IdentityGcpAuthResource) Create(ctx context.Context, req resource.Creat
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityGcpAuthResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity gcp auth role",
-			"Only Machine IdentityGcpAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -293,10 +293,10 @@ func (r *IdentityGcpAuthResource) Read(ctx context.Context, req resource.ReadReq
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityGcpAuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity gcp auth",
-			"Only Machine IdentityGcpAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -352,10 +352,10 @@ func (r *IdentityGcpAuthResource) Update(ctx context.Context, req resource.Updat
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityGcpAuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity gcp auth",
-			"Only Machine IdentityGcpAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}

--- a/internal/provider/resource/identity_kubernetes_auth.go
+++ b/internal/provider/resource/identity_kubernetes_auth.go
@@ -200,10 +200,10 @@ func updateKubernetesAuthStateByApi(ctx context.Context, diagnose diag.Diagnosti
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityKubernetesAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity kubernetes auth",
-			"Only Machine IdentityKubernetesAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -253,10 +253,10 @@ func (r *IdentityKubernetesAuthResource) Create(ctx context.Context, req resourc
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityKubernetesAuthResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity kubernetes auth role",
-			"Only Machine IdentityKubernetesAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -297,10 +297,10 @@ func (r *IdentityKubernetesAuthResource) Read(ctx context.Context, req resource.
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityKubernetesAuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity kubernetes auth",
-			"Only Machine IdentityKubernetesAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -358,10 +358,10 @@ func (r *IdentityKubernetesAuthResource) Update(ctx context.Context, req resourc
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityKubernetesAuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity kubernetes auth",
-			"Only Machine IdentityKubernetesAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}

--- a/internal/provider/resource/identity_universal_auth.go
+++ b/internal/provider/resource/identity_universal_auth.go
@@ -200,10 +200,10 @@ func tfPlanExpandIpFieldAsApiField(ctx context.Context, diagnostics diag.Diagnos
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityUniversalAuthResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity universal auth",
-			"Only Machine IdentityUniversalAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -247,10 +247,10 @@ func (r *IdentityUniversalAuthResource) Create(ctx context.Context, req resource
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityUniversalAuthResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity universal auth role",
-			"Only Machine IdentityUniversalAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -291,10 +291,10 @@ func (r *IdentityUniversalAuthResource) Read(ctx context.Context, req resource.R
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityUniversalAuthResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity universal auth",
-			"Only Machine IdentityUniversalAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -345,10 +345,10 @@ func (r *IdentityUniversalAuthResource) Update(ctx context.Context, req resource
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityUniversalAuthResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity universal auth",
-			"Only Machine IdentityUniversalAuth authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}

--- a/internal/provider/resource/identity_universal_auth_client_secret.go
+++ b/internal/provider/resource/identity_universal_auth_client_secret.go
@@ -121,10 +121,10 @@ func (r *IdentityUniversalAuthClientSecretResource) Configure(_ context.Context,
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *IdentityUniversalAuthClientSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to create identity universal auth client secret",
-			"Only Machine IdentityUniversalAuthClientSecret authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -181,10 +181,10 @@ func (r *IdentityUniversalAuthClientSecretResource) Create(ctx context.Context, 
 
 // Read refreshes the Terraform state with the latest data.
 func (r *IdentityUniversalAuthClientSecretResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to read identity universal auth client secret role",
-			"Only Machine IdentityUniversalAuthClientSecret authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -227,10 +227,10 @@ func (r *IdentityUniversalAuthClientSecretResource) Read(ctx context.Context, re
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *IdentityUniversalAuthClientSecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to update identity universal auth client secret",
-			"Only Machine IdentityUniversalAuthClientSecret authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}
@@ -241,10 +241,10 @@ func (r *IdentityUniversalAuthClientSecretResource) Update(ctx context.Context, 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *IdentityUniversalAuthClientSecretResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 
-	if r.client.Config.AuthStrategy != infisical.AuthStrategy.UNIVERSAL_MACHINE_IDENTITY {
+	if !r.client.Config.IsMachineIdentityAuth {
 		resp.Diagnostics.AddError(
 			"Unable to delete identity universal auth client secret",
-			"Only Machine IdentityUniversalAuthClientSecret authentication is supported for this operation",
+			"Only Machine Identity authentication is supported for this operation",
 		)
 		return
 	}


### PR DESCRIPTION
This PR will address issues encountered by users during machine identity configuration when they're using OIDC auth or some other auth that's not universal auth