### PR TITLE
feat: terraform import support

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1094,15 +1094,6 @@ type GetProjectEnvironmentByIDResponse struct {
 	Environment ProjectEnvironmentByID `json:"environment"`
 }
 
-type GetProjectEnvironmentBySlugRequest struct {
-	Slug      string
-	ProjectID string
-}
-
-type GetProjectEnvironmentBySlugResponse struct {
-	Environment ProjectEnvironment `json:"environment"`
-}
-
 type UpdateProjectEnvironmentRequest struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -281,16 +281,59 @@ type ProjectEnvironment struct {
 	ID   string `json:"id"`
 }
 
+type ProjectEnvironmentByID struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Slug      string `json:"slug"`
+	Position  int    `json:"position"`
+	ProjectID string `json:"projectId"`
+}
+
 type SecretFolder struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	EnvID string `json:"envId"`
 }
 
+type SecretFolderByID struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	EnvID       string `json:"envId"`
+	ProjectID   string `json:"projectId"`
+	Path        string `json:"path"`
+	Environment struct {
+		EnvID   string `json:"envId"`
+		EnvName string `json:"envName"`
+		EnvSlug string `json:"envSlug"`
+	} `json:"environment"`
+}
+
 type SecretImport struct {
 	ID         string `json:"id"`
 	SecretPath string `json:"secretPath"`
 	ImportPath string `json:"importPath"`
+}
+
+type SecretImportByID struct {
+	ID            string `json:"id"`
+	SecretPath    string `json:"secretPath"`
+	ImportPath    string `json:"importPath"`
+	ProjectID     string `json:"projectId"`
+	IsReplication bool   `json:"isReplication"`
+
+	// Imported from
+	ImportEnvironment struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	} `json:"importEnv"`
+
+	// Imported into
+	Environment struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	} `json:"environment"`
 }
 
 type CreateProjectResponse struct {
@@ -1001,6 +1044,16 @@ type GetSecretFolderByIDRequest struct {
 }
 
 type GetSecretFolderByIDResponse struct {
+	Folder SecretFolderByID `json:"folder"`
+}
+
+type GetSecretFolderByPathRequest struct {
+	ProjectID   string
+	Environment string
+	SecretPath  string
+}
+
+type GetSecretFolderByPathResponse struct {
 	Folder SecretFolder `json:"folder"`
 }
 
@@ -1034,11 +1087,19 @@ type DeleteProjectEnvironmentResponse struct {
 }
 
 type GetProjectEnvironmentByIDRequest struct {
-	ID        string `json:"id"`
-	ProjectID string `json:"workspaceId"`
+	ID string
 }
 
 type GetProjectEnvironmentByIDResponse struct {
+	Environment ProjectEnvironmentByID `json:"environment"`
+}
+
+type GetProjectEnvironmentBySlugRequest struct {
+	Slug      string
+	ProjectID string
+}
+
+type GetProjectEnvironmentBySlugResponse struct {
 	Environment ProjectEnvironment `json:"environment"`
 }
 
@@ -1714,15 +1775,23 @@ type DeleteSecretImportResponse struct {
 	SecretImport SecretImport `json:"secretImport"`
 }
 
-type GetSecretImportByIDRequest struct {
+type GetSecretImportRequest struct {
 	ID          string `json:"id"`
 	Environment string `json:"environment"`
 	ProjectID   string `json:"workspaceId"`
 	SecretPath  string `json:"path"`
 }
 
-type GetSecretImportByIDResponse struct {
+type GetSecretImportResponse struct {
 	SecretImport SecretImport `json:"secretImport"`
+}
+
+type GetSecretImportByIDRequest struct {
+	ID string
+}
+
+type GetSecretImportByIDResponse struct {
+	SecretImport SecretImportByID `json:"secretImport"`
 }
 
 type ListSecretImportRequest struct {

--- a/internal/client/project_environment.go
+++ b/internal/client/project_environment.go
@@ -53,7 +53,7 @@ func (client Client) GetProjectEnvironmentByID(request GetProjectEnvironmentByID
 		SetResult(&body).
 		SetHeader("User-Agent", USER_AGENT)
 
-	response, err := httpRequest.Get(fmt.Sprintf("api/v1/workspace/%s/environments/%s", request.ProjectID, request.ID))
+	response, err := httpRequest.Get(fmt.Sprintf("api/v1/workspace/environments/%s", request.ID))
 
 	if response.StatusCode() == http.StatusNotFound {
 		return GetProjectEnvironmentByIDResponse{}, ErrNotFound
@@ -65,6 +65,31 @@ func (client Client) GetProjectEnvironmentByID(request GetProjectEnvironmentByID
 
 	if response.IsError() {
 		return GetProjectEnvironmentByIDResponse{}, fmt.Errorf("GetProjectEnvironmentByID: Unsuccessful response. [response=%v]", string(response.Body()))
+	}
+
+	return body, nil
+}
+
+func (client Client) GetProjectEnvironmentBySlug(request GetProjectEnvironmentBySlugRequest) (GetProjectEnvironmentBySlugResponse, error) {
+	var body GetProjectEnvironmentBySlugResponse
+
+	httpRequest := client.Config.HttpClient.
+		R().
+		SetResult(&body).
+		SetHeader("User-Agent", USER_AGENT)
+
+	response, err := httpRequest.Get(fmt.Sprintf("api/v1/workspace/%s/environments/slug/%s", request.ProjectID, request.Slug))
+
+	if response.StatusCode() == http.StatusNotFound {
+		return GetProjectEnvironmentBySlugResponse{}, ErrNotFound
+	}
+
+	if err != nil {
+		return GetProjectEnvironmentBySlugResponse{}, fmt.Errorf("GetProjectEnvironmentBySlug: Unable to complete api request [err=%s]", err)
+	}
+
+	if response.IsError() {
+		return GetProjectEnvironmentBySlugResponse{}, fmt.Errorf("GetProjectEnvironmentBySlug: Unsuccessful response. [response=%v]", string(response.Body()))
 	}
 
 	return body, nil

--- a/internal/client/project_environment.go
+++ b/internal/client/project_environment.go
@@ -70,31 +70,6 @@ func (client Client) GetProjectEnvironmentByID(request GetProjectEnvironmentByID
 	return body, nil
 }
 
-func (client Client) GetProjectEnvironmentBySlug(request GetProjectEnvironmentBySlugRequest) (GetProjectEnvironmentBySlugResponse, error) {
-	var body GetProjectEnvironmentBySlugResponse
-
-	httpRequest := client.Config.HttpClient.
-		R().
-		SetResult(&body).
-		SetHeader("User-Agent", USER_AGENT)
-
-	response, err := httpRequest.Get(fmt.Sprintf("api/v1/workspace/%s/environments/slug/%s", request.ProjectID, request.Slug))
-
-	if response.StatusCode() == http.StatusNotFound {
-		return GetProjectEnvironmentBySlugResponse{}, ErrNotFound
-	}
-
-	if err != nil {
-		return GetProjectEnvironmentBySlugResponse{}, fmt.Errorf("GetProjectEnvironmentBySlug: Unable to complete api request [err=%s]", err)
-	}
-
-	if response.IsError() {
-		return GetProjectEnvironmentBySlugResponse{}, fmt.Errorf("GetProjectEnvironmentBySlug: Unsuccessful response. [response=%v]", string(response.Body()))
-	}
-
-	return body, nil
-}
-
 func (client Client) UpdateProjectEnvironment(request UpdateProjectEnvironmentRequest) (UpdateProjectEnvironmentResponse, error) {
 	var body UpdateProjectEnvironmentResponse
 	response, err := client.Config.HttpClient.


### PR DESCRIPTION
> [!CAUTION]
> This PR depends on https://github.com/Infisical/infisical/pull/2530

This PR introduces Terraform Import support for Project Environments, Secret Imports, and Secrets folders.

The imports are fully ID based, and only take a single ID as input.


## Examples:


### Project environments
**Terraform:**
```terraform
resource "infisical_project_environment" "test-import" {}
```

**Command:**
```bash
terraform import infisical_project_environment.test-import <ENV_ID>
```


### Secret Imports
**Terraform:**
```terraform

resource "infisical_secret_import" "test-import" {}
```

**Command:**
```bash
terraform import infisical_secret_import.test-import <IMPORT_ID>
```


### Secrets folder
**Terraform:**
```terraform
resource "infisical_secret_folder" "test-import" {}
```

**Command:**
```bash
terraform import infisical_secret_folder.test-import <FOLDER_ID>
```