### PR TITLE
fix: project role drift when no conditions are set

### DIFF
--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -301,7 +301,7 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 			}
 		}
 
-		conditions := &projectRoleResourcePermissionCondition{}
+		var conditions *projectRoleResourcePermissionCondition
 
 		if el["conditions"] == nil {
 			conditions = nil

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -301,13 +301,21 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 			}
 		}
 
-		permissionPlan = append(permissionPlan, projectRoleResourcePermissions{
-			Action:  types.StringValue(action),
-			Subject: types.StringValue(subject),
-			Conditions: &projectRoleResourcePermissionCondition{
+		conditions := &projectRoleResourcePermissionCondition{}
+
+		if environment != "" || secretPath != "" {
+			conditions = &projectRoleResourcePermissionCondition{
 				Environment: types.StringValue(environment),
 				SecretPath:  types.StringValue(secretPath),
-			},
+			}
+		} else if el["conditions"] == nil {
+			conditions = nil
+		}
+
+		permissionPlan = append(permissionPlan, projectRoleResourcePermissions{
+			Action:     types.StringValue(action),
+			Subject:    types.StringValue(subject),
+			Conditions: conditions,
 		})
 	}
 

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -303,13 +303,13 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 
 		conditions := &projectRoleResourcePermissionCondition{}
 
-		if environment != "" || secretPath != "" {
+		if el["conditions"] == nil {
+			conditions = nil
+		} else {
 			conditions = &projectRoleResourcePermissionCondition{
 				Environment: types.StringValue(environment),
 				SecretPath:  types.StringValue(secretPath),
 			}
-		} else if el["conditions"] == nil {
-			conditions = nil
 		}
 
 		permissionPlan = append(permissionPlan, projectRoleResourcePermissions{


### PR DESCRIPTION
As the title says, this PR resolves project roles having an infinite drift when no conditions in the permissions are set.