### PR TITLE
feat: identity multi-auth

### DIFF
--- a/docs/resources/identity.md
+++ b/docs/resources/identity.md
@@ -113,10 +113,7 @@ resource "infisical_identity_kubernetes_auth" "k8-auth" {
 - `org_id` (String) The ID of the organization for the identity
 - `role` (String) The role for the identity. Available default role options are 'admin', 'member', and 'no-access'. If you've created custom roles, you can use their slugs as well.
 
-### Optional
-
-- `auth_modes` (List of String) The authentication types of the identity
-
 ### Read-Only
 
+- `auth_modes` (List of String) The authentication types of the identity
 - `id` (String) The ID of the identity

--- a/docs/resources/identity.md
+++ b/docs/resources/identity.md
@@ -115,7 +115,7 @@ resource "infisical_identity_kubernetes_auth" "k8-auth" {
 
 ### Optional
 
-- `auth_mode` (String) The authentication type of the identity
+- `auth_modes` (List of String) The authentication types of the identity
 
 ### Read-Only
 

--- a/docs/resources/project_identity.md
+++ b/docs/resources/project_identity.md
@@ -84,6 +84,6 @@ Read-Only:
 
 Read-Only:
 
-- `auth_method` (String) The auth method for the identity
+- `auth_methods` (List of String) The auth methods for the identity
 - `id` (String) The ID of the identity
 - `name` (String) The name of the identity

--- a/examples/resources/infisical_identity/resource.tf
+++ b/examples/resources/infisical_identity/resource.tf
@@ -2,89 +2,104 @@ terraform {
   required_providers {
     infisical = {
       # version = <latest version>
-      source = "infisical/infisical"
+      source = "hashicorp.com/edu/infisical"
     }
   }
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host          = "http://localhost:8080" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  client_id     = "72c7a82f-051f-4f72-9d42-57f3401fffdd"
+  client_secret = "91db2a49e38797d444fa8b5ba4d164c9ec0732bdc1ee9990673ea8fe09908310"
 }
 
 # universal authentication identity
 resource "infisical_identity" "universal-auth" {
   name   = "universal-auth"
   role   = "member"
-  org_id = "<org_id>"
+  org_id = "180870b7-f464-4740-8ffe-9d11c9245ea7"
 }
 
-resource "infisical_identity_universal_auth" "ua-auth" {
-  identity_id                 = infisical_identity.universal-auth.id
-  access_token_ttl            = 2592000
-  access_token_max_ttl        = 2592000 * 2
-  access_token_num_uses_limit = 3
+output "universal_auth_identity_id" {
+  value = infisical_identity.universal-auth.id
 }
 
-resource "infisical_identity_universal_auth_client_secret" "client-secret" {
+
+resource "infisical_project_identity" "test-identity" {
+  project_id  = "0a7179b4-931b-4e94-948a-b37b38f17a35"
   identity_id = infisical_identity.universal-auth.id
-
-  depends_on = [infisical_identity_universal_auth.ua-auth]
+  roles = [
+    {
+      role_slug = "admin"
+    }
+  ]
 }
 
-output "client_secret" {
-  sensitive = true
-  value     = infisical_identity_universal_auth_client_secret.client-secret.client_secret
-}
+# resource "infisical_identity_universal_auth" "ua-auth" {
+#   identity_id                 = infisical_identity.universal-auth.id
+#   access_token_ttl            = 2592000
+#   access_token_max_ttl        = 2592000 * 2
+#   access_token_num_uses_limit = 3
+# }
 
-resource "infisical_identity" "aws-auth" {
-  name   = "aws-auth"
-  role   = "member"
-  org_id = "<org_id>"
-}
+# resource "infisical_identity_universal_auth_client_secret" "client-secret" {
+#   identity_id = infisical_identity.universal-auth.id
 
-resource "infisical_identity_aws_auth" "aws-auth" {
-  identity_id                 = infisical_identity.aws-auth.id
-  access_token_ttl            = 2592000
-  access_token_max_ttl        = 2592000 * 2
-  access_token_num_uses_limit = 3
-  allowed_principal_arns      = ["arn:aws:iam::123456789012:user/MyUserName"]
-  allowed_account_ids         = ["123456789012", "123456789013"]
-}
+#   depends_on = [infisical_identity_universal_auth.ua-auth]
+# }
 
-resource "infisical_identity" "azure-auth" {
-  name   = "azure-auth"
-  role   = "member"
-  org_id = "<org_id>"
-}
+# output "client_secret" {
+#   sensitive = true
+#   value     = infisical_identity_universal_auth_client_secret.client-secret.client_secret
+# }
 
-resource "infisical_identity_azure_auth" "azure-auth" {
-  identity_id = infisical_identity.azure-auth.id
-  tenant_id   = "TENANT_ID"
-}
+# resource "infisical_identity" "aws-auth" {
+#   name   = "aws-auth"
+#   role   = "member"
+#   org_id = "<org_id>"
+# }
 
-resource "infisical_identity" "gcp-auth" {
-  name   = "gcp-auth"
-  role   = "member"
-  org_id = "<org_id>"
-}
+# resource "infisical_identity_aws_auth" "aws-auth" {
+#   identity_id                 = infisical_identity.aws-auth.id
+#   access_token_ttl            = 2592000
+#   access_token_max_ttl        = 2592000 * 2
+#   access_token_num_uses_limit = 3
+#   allowed_principal_arns      = ["arn:aws:iam::123456789012:user/MyUserName"]
+#   allowed_account_ids         = ["123456789012", "123456789013"]
+# }
 
-resource "infisical_identity_gcp_auth" "gcp-auth" {
-  identity_id = infisical_identity.gcp-auth.id
-  type        = "gce"
-}
+# resource "infisical_identity" "azure-auth" {
+#   name   = "azure-auth"
+#   role   = "member"
+#   org_id = "<org_id>"
+# }
 
-resource "infisical_identity" "k8-auth" {
-  name   = "k8-auth"
-  role   = "member"
-  org_id = "<org_id>"
-}
+# resource "infisical_identity_azure_auth" "azure-auth" {
+#   identity_id = infisical_identity.azure-auth.id
+#   tenant_id   = "TENANT_ID"
+# }
 
-resource "infisical_identity_kubernetes_auth" "k8-auth" {
-  identity_id        = infisical_identity.k8-auth.id
-  kubernetes_host    = "http://example.com"
-  token_reviewer_jwt = "ey<example>"
-  allowed_namespaces = ["namespace-a", "namespace-b"]
-}
+# resource "infisical_identity" "gcp-auth" {
+#   name   = "gcp-auth"
+#   role   = "member"
+#   org_id = "<org_id>"
+# }
+
+# resource "infisical_identity_gcp_auth" "gcp-auth" {
+#   identity_id = infisical_identity.gcp-auth.id
+#   type        = "gce"
+# }
+
+# resource "infisical_identity" "k8-auth" {
+#   name   = "k8-auth"
+#   role   = "member"
+#   org_id = "<org_id>"
+# }
+
+# resource "infisical_identity_kubernetes_auth" "k8-auth" {
+#   identity_id        = infisical_identity.k8-auth.id
+#   kubernetes_host    = "http://example.com"
+#   token_reviewer_jwt = "ey<example>"
+#   allowed_namespaces = ["namespace-a", "namespace-b"]
+# }
 

--- a/examples/resources/infisical_identity/resource.tf
+++ b/examples/resources/infisical_identity/resource.tf
@@ -2,104 +2,88 @@ terraform {
   required_providers {
     infisical = {
       # version = <latest version>
-      source = "hashicorp.com/edu/infisical"
+      source = "infisical/infisical"
     }
   }
 }
 
 provider "infisical" {
-  host          = "http://localhost:8080" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "72c7a82f-051f-4f72-9d42-57f3401fffdd"
-  client_secret = "91db2a49e38797d444fa8b5ba4d164c9ec0732bdc1ee9990673ea8fe09908310"
+  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  client_id     = "<machine-identity-client-id>"
+  client_secret = "<machine-identity-client-secret>"
 }
 
 # universal authentication identity
 resource "infisical_identity" "universal-auth" {
   name   = "universal-auth"
   role   = "member"
-  org_id = "180870b7-f464-4740-8ffe-9d11c9245ea7"
+  org_id = "<org_id>"
 }
 
-output "universal_auth_identity_id" {
-  value = infisical_identity.universal-auth.id
+resource "infisical_identity_universal_auth" "ua-auth" {
+  identity_id                 = infisical_identity.universal-auth.id
+  access_token_ttl            = 2592000
+  access_token_max_ttl        = 2592000 * 2
+  access_token_num_uses_limit = 3
 }
 
-
-resource "infisical_project_identity" "test-identity" {
-  project_id  = "0a7179b4-931b-4e94-948a-b37b38f17a35"
+resource "infisical_identity_universal_auth_client_secret" "client-secret" {
   identity_id = infisical_identity.universal-auth.id
-  roles = [
-    {
-      role_slug = "admin"
-    }
-  ]
+
+  depends_on = [infisical_identity_universal_auth.ua-auth]
 }
 
-# resource "infisical_identity_universal_auth" "ua-auth" {
-#   identity_id                 = infisical_identity.universal-auth.id
-#   access_token_ttl            = 2592000
-#   access_token_max_ttl        = 2592000 * 2
-#   access_token_num_uses_limit = 3
-# }
+output "client_secret" {
+  sensitive = true
+  value     = infisical_identity_universal_auth_client_secret.client-secret.client_secret
+}
 
-# resource "infisical_identity_universal_auth_client_secret" "client-secret" {
-#   identity_id = infisical_identity.universal-auth.id
+resource "infisical_identity" "aws-auth" {
+  name   = "aws-auth"
+  role   = "member"
+  org_id = "<org_id>"
+}
 
-#   depends_on = [infisical_identity_universal_auth.ua-auth]
-# }
+resource "infisical_identity_aws_auth" "aws-auth" {
+  identity_id                 = infisical_identity.aws-auth.id
+  access_token_ttl            = 2592000
+  access_token_max_ttl        = 2592000 * 2
+  access_token_num_uses_limit = 3
+  allowed_principal_arns      = ["arn:aws:iam::123456789012:user/MyUserName"]
+  allowed_account_ids         = ["123456789012", "123456789013"]
+}
 
-# output "client_secret" {
-#   sensitive = true
-#   value     = infisical_identity_universal_auth_client_secret.client-secret.client_secret
-# }
+resource "infisical_identity" "azure-auth" {
+  name   = "azure-auth"
+  role   = "member"
+  org_id = "<org_id>"
+}
 
-# resource "infisical_identity" "aws-auth" {
-#   name   = "aws-auth"
-#   role   = "member"
-#   org_id = "<org_id>"
-# }
+resource "infisical_identity_azure_auth" "azure-auth" {
+  identity_id = infisical_identity.azure-auth.id
+  tenant_id   = "TENANT_ID"
+}
 
-# resource "infisical_identity_aws_auth" "aws-auth" {
-#   identity_id                 = infisical_identity.aws-auth.id
-#   access_token_ttl            = 2592000
-#   access_token_max_ttl        = 2592000 * 2
-#   access_token_num_uses_limit = 3
-#   allowed_principal_arns      = ["arn:aws:iam::123456789012:user/MyUserName"]
-#   allowed_account_ids         = ["123456789012", "123456789013"]
-# }
+resource "infisical_identity" "gcp-auth" {
+  name   = "gcp-auth"
+  role   = "member"
+  org_id = "<org_id>"
+}
 
-# resource "infisical_identity" "azure-auth" {
-#   name   = "azure-auth"
-#   role   = "member"
-#   org_id = "<org_id>"
-# }
+resource "infisical_identity_gcp_auth" "gcp-auth" {
+  identity_id = infisical_identity.gcp-auth.id
+  type        = "gce"
+}
 
-# resource "infisical_identity_azure_auth" "azure-auth" {
-#   identity_id = infisical_identity.azure-auth.id
-#   tenant_id   = "TENANT_ID"
-# }
+resource "infisical_identity" "k8-auth" {
+  name   = "k8-auth"
+  role   = "member"
+  org_id = "<org_id>"
+}
 
-# resource "infisical_identity" "gcp-auth" {
-#   name   = "gcp-auth"
-#   role   = "member"
-#   org_id = "<org_id>"
-# }
-
-# resource "infisical_identity_gcp_auth" "gcp-auth" {
-#   identity_id = infisical_identity.gcp-auth.id
-#   type        = "gce"
-# }
-
-# resource "infisical_identity" "k8-auth" {
-#   name   = "k8-auth"
-#   role   = "member"
-#   org_id = "<org_id>"
-# }
-
-# resource "infisical_identity_kubernetes_auth" "k8-auth" {
-#   identity_id        = infisical_identity.k8-auth.id
-#   kubernetes_host    = "http://example.com"
-#   token_reviewer_jwt = "ey<example>"
-#   allowed_namespaces = ["namespace-a", "namespace-b"]
-# }
-
+resource "infisical_identity_kubernetes_auth" "k8-auth" {
+  identity_id        = infisical_identity.k8-auth.id
+  kubernetes_host    = "http://example.com"
+  token_reviewer_jwt = "ey<example>"
+  allowed_namespaces = ["namespace-a", "namespace-b"]
+}

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -77,9 +77,9 @@ type ProjectIdentity struct {
 	IdentityID string `json:"identityId"`
 	Roles      []ProjectMemberRole
 	Identity   struct {
-		Name       string `json:"name"`
-		Id         string `json:"id"`
-		AuthMethod string `json:"authMethod"`
+		Name        string   `json:"name"`
+		Id          string   `json:"id"`
+		AuthMethods []string `json:"authMethods"`
 	} `json:"identity"`
 }
 
@@ -110,11 +110,11 @@ type OrgIdentity struct {
 }
 
 type Identity struct {
-	Name       string    `json:"name"`
-	ID         string    `json:"id"`
-	AuthMethod string    `json:"authMethod"`
-	CreatedAt  time.Time `json:"createdAt"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	Name        string    `json:"name"`
+	ID          string    `json:"id"`
+	AuthMethods []string  `json:"authMethods"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 type IdentityUniversalAuth struct {

--- a/internal/provider/resource/identity.go
+++ b/internal/provider/resource/identity.go
@@ -66,7 +66,6 @@ func (r *IdentityResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				ElementType: types.StringType,
 				Description: "The authentication types of the identity",
 				Computed:    true,
-				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/resource/identity.go
+++ b/internal/provider/resource/identity.go
@@ -6,6 +6,7 @@ import (
 	infisical "terraform-provider-infisical/internal/client"
 	infisicalclient "terraform-provider-infisical/internal/client"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -25,11 +26,11 @@ type IdentityResource struct {
 
 // IdentityResourceSourceModel describes the data source data model.
 type IdentityResourceModel struct {
-	ID       types.String `tfsdk:"id"`
-	Name     types.String `tfsdk:"name"`
-	AuthMode types.String `tfsdk:"auth_mode"`
-	Role     types.String `tfsdk:"role"`
-	OrgID    types.String `tfsdk:"org_id"`
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	AuthModes types.List   `tfsdk:"auth_modes"`
+	Role      types.String `tfsdk:"role"`
+	OrgID     types.String `tfsdk:"org_id"`
 }
 
 // Metadata returns the resource type name.
@@ -61,8 +62,9 @@ func (r *IdentityResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 
-			"auth_mode": schema.StringAttribute{
-				Description: "The authentication type of the identity",
+			"auth_modes": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The authentication types of the identity",
 				Computed:    true,
 				Optional:    true,
 			},
@@ -123,10 +125,14 @@ func (r *IdentityResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	plan.ID = types.StringValue(newIdentity.Identity.ID)
-	if newIdentity.Identity.AuthMethod != "" {
-		plan.AuthMode = types.StringValue(newIdentity.Identity.AuthMethod)
+	if len(newIdentity.Identity.AuthMethods) > 0 {
+		elements := make([]attr.Value, len(newIdentity.Identity.AuthMethods))
+		for i, method := range newIdentity.Identity.AuthMethods {
+			elements[i] = types.StringValue(method)
+		}
+		plan.AuthModes = types.ListValueMust(types.StringType, elements)
 	} else {
-		plan.AuthMode = types.StringNull()
+		plan.AuthModes = types.ListNull(types.StringType)
 	}
 
 	diags = resp.State.Set(ctx, plan)
@@ -174,10 +180,14 @@ func (r *IdentityResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	state.Name = types.StringValue(orgIdentity.Identity.Name)
-	if orgIdentity.Identity.AuthMethod != "" {
-		state.AuthMode = types.StringValue(orgIdentity.Identity.AuthMethod)
+	if len(orgIdentity.Identity.AuthMethods) > 0 {
+		elements := make([]attr.Value, len(orgIdentity.Identity.AuthMethods))
+		for i, method := range orgIdentity.Identity.AuthMethods {
+			elements[i] = types.StringValue(method)
+		}
+		state.AuthModes = types.ListValueMust(types.StringType, elements)
 	} else {
-		state.AuthMode = types.StringNull()
+		state.AuthModes = types.ListNull(types.StringType)
 	}
 
 	if orgIdentity.CustomRole != nil {
@@ -232,10 +242,14 @@ func (r *IdentityResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	if orgIdentity.Identity.AuthMethod != "" {
-		plan.AuthMode = types.StringValue(orgIdentity.Identity.AuthMethod)
+	if len(orgIdentity.Identity.AuthMethods) > 0 {
+		elements := make([]attr.Value, len(orgIdentity.Identity.AuthMethods))
+		for i, method := range orgIdentity.Identity.AuthMethods {
+			elements[i] = types.StringValue(method)
+		}
+		plan.AuthModes = types.ListValueMust(types.StringType, elements)
 	} else {
-		plan.AuthMode = types.StringNull()
+		plan.AuthModes = types.ListNull(types.StringType)
 	}
 
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/resource/project_identity_resource.go
+++ b/internal/provider/resource/project_identity_resource.go
@@ -6,6 +6,7 @@ import (
 	infisical "terraform-provider-infisical/internal/client"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -40,9 +41,9 @@ type ProjectIdentityResourceModel struct {
 }
 
 type ProjectIdentityDetails struct {
-	ID         types.String `tfsdk:"id"`
-	Name       types.String `tfsdk:"name"`
-	AuthMethod types.String `tfsdk:"auth_method"`
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	AuthMethods types.List   `tfsdk:"auth_methods"`
 }
 
 type ProjectIdentityRole struct {
@@ -92,8 +93,9 @@ func (r *ProjectIdentityResource) Schema(_ context.Context, _ resource.SchemaReq
 						Description: "The name of the identity",
 						Computed:    true,
 					},
-					"auth_method": schema.StringAttribute{
-						Description: "The auth method for the identity",
+					"auth_methods": schema.ListAttribute{
+						ElementType: types.StringType,
+						Description: "The auth methods for the identity",
 						Computed:    true,
 					},
 				},
@@ -290,10 +292,16 @@ func (r *ProjectIdentityResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	identityDetails := ProjectIdentityDetails{
-		ID:         types.StringValue(projectIdentityDetails.Membership.Identity.Id),
-		Name:       types.StringValue(projectIdentityDetails.Membership.Identity.Name),
-		AuthMethod: types.StringValue(projectIdentityDetails.Membership.Identity.AuthMethod),
+		ID:   types.StringValue(projectIdentityDetails.Membership.Identity.Id),
+		Name: types.StringValue(projectIdentityDetails.Membership.Identity.Name),
 	}
+
+	elements := make([]attr.Value, len(projectIdentityDetails.Membership.Identity.AuthMethods))
+	for i, method := range projectIdentityDetails.Membership.Identity.AuthMethods {
+		elements[i] = types.StringValue(method)
+	}
+	identityDetails.AuthMethods = types.ListValueMust(types.StringType, elements)
+
 	diags = resp.State.SetAttribute(ctx, path.Root("identity"), identityDetails)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -363,10 +371,16 @@ func (r *ProjectIdentityResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	identityDetails := ProjectIdentityDetails{
-		ID:         types.StringValue(projectIdentityDetails.Membership.Identity.Id),
-		Name:       types.StringValue(projectIdentityDetails.Membership.Identity.Name),
-		AuthMethod: types.StringValue(projectIdentityDetails.Membership.Identity.AuthMethod),
+		ID:   types.StringValue(projectIdentityDetails.Membership.Identity.Id),
+		Name: types.StringValue(projectIdentityDetails.Membership.Identity.Name),
 	}
+
+	elements := make([]attr.Value, len(projectIdentityDetails.Membership.Identity.AuthMethods))
+	for i, method := range projectIdentityDetails.Membership.Identity.AuthMethods {
+		elements[i] = types.StringValue(method)
+	}
+	identityDetails.AuthMethods = types.ListValueMust(types.StringType, elements)
+
 	diags = resp.State.SetAttribute(ctx, path.Root("identity"), identityDetails)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -512,10 +526,16 @@ func (r *ProjectIdentityResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	identityDetails := ProjectIdentityDetails{
-		ID:         types.StringValue(projectIdentityDetails.Membership.Identity.Id),
-		Name:       types.StringValue(projectIdentityDetails.Membership.Identity.Name),
-		AuthMethod: types.StringValue(projectIdentityDetails.Membership.Identity.AuthMethod),
+		ID:   types.StringValue(projectIdentityDetails.Membership.Identity.Id),
+		Name: types.StringValue(projectIdentityDetails.Membership.Identity.Name),
 	}
+
+	elements := make([]attr.Value, len(projectIdentityDetails.Membership.Identity.AuthMethods))
+	for i, method := range projectIdentityDetails.Membership.Identity.AuthMethods {
+		elements[i] = types.StringValue(method)
+	}
+	identityDetails.AuthMethods = types.ListValueMust(types.StringType, elements)
+
 	diags = resp.State.SetAttribute(ctx, path.Root("identity"), identityDetails)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
This PR implements a fix for Terraform to properly support identities with multiple auth methods. The `auth_methods` and `auth_modes` variables aren't actually used, but they are preserved in the state. This PR fixes the state to include an array of auth methods, returned by the API.