### PR TITLE
feat: allow changing `folder_path` on secret folder resoruces

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1107,6 +1107,12 @@ type UpdateSecretFolderResponse struct {
 	Folder SecretFolder `json:"folder"`
 }
 
+type MoveSecretFolderRequest struct {
+	ID        string
+	ProjectID string `json:"projectId"`
+	NewPath   string `json:"newPath"`
+}
+
 type DeleteSecretFolderRequest struct {
 	ID          string `json:"id"`
 	Environment string `json:"environment"`

--- a/internal/client/secret_folder.go
+++ b/internal/client/secret_folder.go
@@ -91,6 +91,26 @@ func (client Client) UpdateSecretFolder(request UpdateSecretFolderRequest) (Upda
 	return body, nil
 }
 
+func (client Client) MoveSecretFolder(request MoveSecretFolderRequest) (UpdateSecretFolderResponse, error) {
+	var body UpdateSecretFolderResponse
+	response, err := client.Config.HttpClient.
+		R().
+		SetResult(&body).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Patch(fmt.Sprintf("api/v1/folders/%s/move", request.ID))
+
+	if err != nil {
+		return UpdateSecretFolderResponse{}, fmt.Errorf("CallMoveSecretFolder: Unable to complete api request [err=%s]", err)
+	}
+
+	if response.IsError() {
+		return UpdateSecretFolderResponse{}, fmt.Errorf("CallMoveSecretFolder: Unsuccessful response. [response=%s]", string(response.Body()))
+	}
+
+	return body, nil
+}
+
 func (client Client) DeleteSecretFolder(request DeleteSecretFolderRequest) (DeleteSecretFolderResponse, error) {
 	var body DeleteSecretFolderResponse
 	response, err := client.Config.HttpClient.

--- a/internal/provider/resource/project_secret_folder.go
+++ b/internal/provider/resource/project_secret_folder.go
@@ -51,9 +51,8 @@ func (r *projectSecretFolderResource) Schema(_ context.Context, _ resource.Schem
 				Required:    true,
 			},
 			"folder_path": schema.StringAttribute{
-				Description:   "The path where the folder should be created/updated",
-				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Description: "The path where the folder should be created/updated",
+				Required:    true,
 			},
 			"environment_slug": schema.StringAttribute{
 				Description:   "The environment slug of the folder to modify/create",
@@ -71,8 +70,9 @@ func (r *projectSecretFolderResource) Schema(_ context.Context, _ resource.Schem
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"environment_id": schema.StringAttribute{
-				Description: "The ID of the environment",
-				Computed:    true,
+				Description:   "The ID of the environment",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -209,6 +209,22 @@ func (r *projectSecretFolderResource) Update(ctx context.Context, req resource.U
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if state.SecretPath.ValueString() != plan.SecretPath.ValueString() {
+		_, err := r.client.MoveSecretFolder(infisical.MoveSecretFolderRequest{
+			ID:        state.ID.ValueString(),
+			ProjectID: state.ProjectID.ValueString(),
+			NewPath:   plan.SecretPath.ValueString(),
+		})
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error moving secret folder",
+				"Couldn't move secret folder from Infiscial, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	updatedFolder, err := r.client.UpdateSecretFolder(infisical.UpdateSecretFolderRequest{


### PR DESCRIPTION
This PR removes the forceful replacement of a resource when the folder path is changed. Instead it will now move the folder to the newly defined folder path.

> [!CAUTION]
> This PR depends on https://github.com/Infisical/infisical/pull/2721, and the mentioned pull request must be merged and deployed before this is released. 