### PR TITLE
hotfix: integrations url invalid

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1547,9 +1547,9 @@ type CreateIntegrationAuthRequest struct {
 	AccessToken         string              `json:"accessToken,omitempty"`
 	AWSAssumeIamRoleArn string              `json:"awsAssumeIamRoleArn,omitempty"`
 	RefreshToken        string              `json:"refreshToken,omitempty"`
+	URL                 string              `json:"url,omitempty"`
 	ProjectID           string              `json:"workspaceId"`
 	Integration         IntegrationAuthType `json:"integration"`
-	URL                 string              `json:"url"`
 }
 
 type CreateIntegrationAuthResponse struct {


### PR DESCRIPTION
This PR fixes a breaking change in 0.12.1

```
CreateIntegrationAuth: Unsuccessful response.
[response={"statusCode":401,"message":[{"validation":"url","code":"invalid_string","message":"Invalid
url","path":["url"]}],"error":"ValidationFailure"}]
```