### PR TITLE
misc: update permissions_v2 field to use list instead of set

### DIFF
--- a/docs/resources/project_identity_specific_privilege.md
+++ b/docs/resources/project_identity_specific_privilege.md
@@ -81,7 +81,7 @@ resource "infisical_project_identity_specific_privilege" "test-privilege" {
 
 - `is_temporary` (Boolean) Flag to indicate the assigned specific privilege is temporary or not. When is_temporary is true fields temporary_mode, temporary_range and temporary_access_start_time is required.
 - `permission` (Attributes) (DEPRECATED, USE permissions_v2. Refer to the migration guide in https://infisical.com/docs/internals/permissions#migrating-from-permission-v1-to-permission-v2) The permissions assigned to the project identity specific privilege (see [below for nested schema](#nestedatt--permission))
-- `permissions_v2` (Attributes Set) The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
+- `permissions_v2` (Attributes List) The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
 - `slug` (String) The slug for the new privilege
 - `temporary_access_end_time` (String) ISO time for which temporary access will end. Computed based on temporary_range and temporary_access_start_time
 - `temporary_access_start_time` (String) ISO time for which temporary access should begin. The current time is used by default.

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -70,7 +70,7 @@ resource "infisical_project_role" "biller" {
 
 - `description` (String) The description for the new role. Defaults to an empty string.
 - `permissions` (Attributes List) (DEPRECATED, USE permissions_v2. Refer to the migration guide in https://infisical.com/docs/internals/permissions#migrating-from-permission-v1-to-permission-v2) The permissions assigned to the project role (see [below for nested schema](#nestedatt--permissions))
-- `permissions_v2` (Attributes Set) The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
+- `permissions_v2` (Attributes List) The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
 
 ### Read-Only
 

--- a/internal/provider/resource/project_identity_specific_privilege.go
+++ b/internal/provider/resource/project_identity_specific_privilege.go
@@ -164,7 +164,7 @@ func (r *projectIdentitySpecificPrivilegeResourceResource) Schema(_ context.Cont
 					},
 				},
 			},
-			"permissions_v2": schema.SetNestedAttribute{
+			"permissions_v2": schema.ListNestedAttribute{
 				Optional:    true,
 				Description: "The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage.",
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -117,7 +117,7 @@ func (r *projectRoleResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"permissions_v2": schema.SetNestedAttribute{
+			"permissions_v2": schema.ListNestedAttribute{
 				Optional:    true,
 				Description: "The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage.",
 				NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
This PR updates field type of permissions_v2 field to a list which will enforce the order of elements. In the context of permissions, the order matters a lot 