### PR TITLE
fix(project-environment): empty position arg defaults to 0

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1150,7 +1150,7 @@ type CreateProjectEnvironmentRequest struct {
 	Name      string `json:"name"`
 	Slug      string `json:"slug"`
 	ProjectID string `json:"workspaceId"`
-	Position  int64  `json:"position"`
+	Position  int64  `json:"position,omitempty"`
 }
 
 type CreateProjectEnvironmentResponse struct {


### PR DESCRIPTION
The `position` parameter was defaulting to 0 when nothing is defined, which is not allowed by our API. I've added `omitempty` to the request field.