### PR TITLE
fix(oidc-auth): comma formatted bound claims required space formatting

### DIFF
--- a/internal/pkg/modifiers/comma_space_map_modifier.go
+++ b/internal/pkg/modifiers/comma_space_map_modifier.go
@@ -1,0 +1,60 @@
+package pkg
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// CommaSpaceMapModifier ensures consistent formatting of comma-separated strings in map values
+type CommaSpaceMapModifier struct{}
+
+func (m CommaSpaceMapModifier) Description(ctx context.Context) string {
+	return "Ensures consistent formatting of comma-separated strings in map values with spaces after commas"
+}
+
+func (m CommaSpaceMapModifier) MarkdownDescription(ctx context.Context) string {
+	return "Ensures consistent formatting of comma-separated strings in map values with spaces after commas"
+}
+
+func (m CommaSpaceMapModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	if req.PlanValue.IsUnknown() || req.PlanValue.IsNull() {
+		return
+	}
+
+	planElements := req.PlanValue.Elements()
+	newElements := make(map[string]types.String)
+
+	for key, value := range planElements {
+		strValue := value.(types.String)
+		if !strValue.IsNull() && !strValue.IsUnknown() {
+			parts := strings.Split(strValue.ValueString(), ",")
+
+			// Trim spaces from each part and rejoin with ", "
+			for i, part := range parts {
+				parts[i] = strings.TrimSpace(part)
+			}
+
+			formattedValue := strings.Join(parts, ", ")
+
+			newElements[key] = types.StringValue(formattedValue)
+		} else {
+			// Preserve null/unknown values
+			newElements[key] = strValue
+		}
+	}
+
+	newMapValue, diags := types.MapValueFrom(ctx, types.StringType, newElements)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.PlanValue = newMapValue
+}
+
+func CommaSpaceMap() CommaSpaceMapModifier {
+	return CommaSpaceMapModifier{}
+}

--- a/internal/pkg/modifiers/comma_space_map_modifier.go
+++ b/internal/pkg/modifiers/comma_space_map_modifier.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// CommaSpaceMapModifier ensures consistent formatting of comma-separated strings in map values
+// CommaSpaceMapModifier ensures consistent formatting of comma-separated strings in map values.
 type CommaSpaceMapModifier struct{}
 
 func (m CommaSpaceMapModifier) Description(ctx context.Context) string {
@@ -41,7 +41,12 @@ func (m CommaSpaceMapModifier) PlanModifyMap(ctx context.Context, req planmodifi
 	}
 
 	for key, value := range planElements {
-		strValue := value.(types.String)
+		strValue, ok := value.(types.String)
+
+		if !ok {
+			continue
+		}
+
 		if !strValue.IsNull() && !strValue.IsUnknown() {
 			parts := strings.Split(strValue.ValueString(), ",")
 			for i, part := range parts {
@@ -70,7 +75,7 @@ func (m CommaSpaceMapModifier) PlanModifyMap(ctx context.Context, req planmodifi
 	resp.PlanValue = newMapValue
 }
 
-// CommaSpaceMap returns a new instance of CommaSpaceMapModifier
+// CommaSpaceMap returns a new instance of CommaSpaceMapModifier.
 func CommaSpaceMap() CommaSpaceMapModifier {
 	return CommaSpaceMapModifier{}
 }

--- a/internal/provider/resource/identity_oidc_auth.go
+++ b/internal/provider/resource/identity_oidc_auth.go
@@ -183,8 +183,9 @@ func updateOidcAuthStateByApi(ctx context.Context, diagnose diag.Diagnostics, pl
 		useSpaces := false
 		if !plan.BoundClaims.IsNull() {
 			if planValue, ok := plan.BoundClaims.Elements()[key]; ok {
-				planStr := planValue.(types.String).ValueString()
-				useSpaces = strings.Contains(planStr, ", ")
+				if planStr, ok := planValue.(types.String); ok {
+					useSpaces = strings.Contains(planStr.ValueString(), ", ")
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed bug causing Terraform to provide invalid plan error when `bound_claims.repository` was not formatted WITH spaces between comma-separated items.

The OIDC auth resource now supports both with/without spaces between comma-separated items.