### PR TITLE
misc: added doc reference for permissions_v2 conditions usgae

### DIFF
--- a/docs/resources/project_identity_specific_privilege.md
+++ b/docs/resources/project_identity_specific_privilege.md
@@ -124,5 +124,5 @@ Required:
 
 Optional:
 
-- `conditions` (String) When specified, only matching conditions will be allowed to access given resource.
+- `conditions` (String) When specified, only matching conditions will be allowed to access given resource. Refer to the documentation in https://infisical.com/docs/internals/permissions#conditions for the complete list of supported properties and operators.
 - `inverted` (Boolean) Whether rule forbids. Set this to true if permission forbids.

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -111,5 +111,5 @@ Required:
 
 Optional:
 
-- `conditions` (String) When specified, only matching conditions will be allowed to access given resource.
+- `conditions` (String) When specified, only matching conditions will be allowed to access given resource. Refer to the documentation in https://infisical.com/docs/internals/permissions#conditions for the complete list of supported properties and operators.
 - `inverted` (Boolean) Whether rule forbids. Set this to true if permission forbids.

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -51,6 +51,9 @@ resource "infisical_project_role" "biller" {
           "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
+        secretPath = {
+          "$eq" = "/"
+        }
       })
     },
   ]

--- a/examples/resources/infisical_project_role/resource.tf
+++ b/examples/resources/infisical_project_role/resource.tf
@@ -36,6 +36,9 @@ resource "infisical_project_role" "biller" {
           "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
+        secretPath = {
+          "$eq" = "/"
+        }
       })
     },
   ]

--- a/internal/provider/resource/project_identity_specific_privilege.go
+++ b/internal/provider/resource/project_identity_specific_privilege.go
@@ -186,7 +186,7 @@ func (r *projectIdentitySpecificPrivilegeResourceResource) Schema(_ context.Cont
 						},
 						"conditions": schema.StringAttribute{
 							Optional:    true,
-							Description: "When specified, only matching conditions will be allowed to access given resource.",
+							Description: "When specified, only matching conditions will be allowed to access given resource. Refer to the documentation in https://infisical.com/docs/internals/permissions#conditions for the complete list of supported properties and operators.",
 							PlanModifiers: []planmodifier.String{
 								pkg.JsonEquivalentModifier{},
 							},

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -139,7 +139,7 @@ func (r *projectRoleResource) Schema(_ context.Context, _ resource.SchemaRequest
 						},
 						"conditions": schema.StringAttribute{
 							Optional:    true,
-							Description: "When specified, only matching conditions will be allowed to access given resource.",
+							Description: "When specified, only matching conditions will be allowed to access given resource. Refer to the documentation in https://infisical.com/docs/internals/permissions#conditions for the complete list of supported properties and operators.",
 							PlanModifiers: []planmodifier.String{
 								pkg.JsonEquivalentModifier{},
 							},


### PR DESCRIPTION
This PRs adds an example of using `secretPath` in the conditions object of permissions_v2. This also adds a reference to the documentation for usage of conditions 