### PR TITLE
fix: addressed issue where integration is disabled when updated

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1676,7 +1676,7 @@ type UpdateIntegrationRequest struct {
 	Owner             string                 `json:"owner,omitempty"`
 	Environment       string                 `json:"environment,omitempty"`
 	Metadata          map[string]interface{} `json:"metadata,omitempty"`
-	IsActive          bool                   `json:"isActive"`
+	IsActive          bool                   `json:"isActive,omitempty"`
 	Region            string                 `json:"region,omitempty"`
 	Path              string                 `json:"path,omitempty"`
 }

--- a/internal/provider/resource/integration_aws_parameter_store.go
+++ b/internal/provider/resource/integration_aws_parameter_store.go
@@ -443,6 +443,7 @@ func (r *IntegrationAWSParameterStoreResource) Update(ctx context.Context, req r
 		SecretPath:  plan.SecretPath.ValueString(),
 		Region:      plan.AWSRegion.ValueString(),
 		Path:        plan.AWSPath.ValueString(),
+		IsActive:    true,
 	})
 
 	if err != nil {

--- a/internal/provider/resource/integration_aws_secrets_manager.go
+++ b/internal/provider/resource/integration_aws_secrets_manager.go
@@ -505,7 +505,9 @@ func (r *IntegrationAWSSecretsManagerResource) Update(ctx context.Context, req r
 		Environment: plan.Environment.ValueString(),
 		SecretPath:  plan.SecretPath.ValueString(),
 		Region:      plan.AWSRegion.ValueString(),
+		IsActive:    true,
 	}
+
 	if plan.MappingBehavior.ValueString() == MAPPING_BEHAVIOR_MANY_TO_ONE {
 		updateIntegrationRequest.App = plan.AWSPath.ValueString()
 	}

--- a/internal/provider/resource/integration_circleci.go
+++ b/internal/provider/resource/integration_circleci.go
@@ -274,6 +274,7 @@ func (r *IntegrationCircleCIResource) Update(ctx context.Context, req resource.U
 		App:         plan.CircleCIProjectID.ValueString(), // Needs to be the project slug
 		AppID:       plan.CircleCIProjectID.ValueString(), // Needs to be the project ID
 		Owner:       plan.CircleCIOrgSlug.ValueString(),   // Needs to be the organization slug
+		IsActive:    true,
 	})
 
 	if err != nil {

--- a/internal/provider/resource/integration_databricks.go
+++ b/internal/provider/resource/integration_databricks.go
@@ -270,6 +270,7 @@ func (r *IntegrationDatabricksResource) Update(ctx context.Context, req resource
 		Environment: plan.Environment.ValueString(),
 		SecretPath:  plan.SecretPath.ValueString(),
 		App:         plan.DatabricksSecretScope.ValueString(),
+		IsActive:    true,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This ensures that when integrations are updated, it doesn't disable the integration sync entirely.
