### PR TITLE
show how to use the JWT for OIDC auth in the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Optional:
 
 Optional:
 
-- `identity_id` (String, Sensitive) Machine identity ID. Used to fetch/modify secrets for a given project
+- `identity_id` (String, Sensitive) Machine identity ID. Used to fetch/modify secrets for a given project. Requires environment variable "INFISICAL_AUTH_JWT" from OIDC IDP.
 
 
 <a id="nestedatt--auth--universal"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Optional:
 
 Optional:
 
-- `identity_id` (String, Sensitive) Machine identity ID. Used to fetch/modify secrets for a given project. Requires environment variable "INFISICAL_AUTH_JWT" from OIDC IDP.
+- `identity_id` (String, Sensitive) Machine identity ID. Used to fetch/modify secrets for a given project. Requires the environment variable `INFISICAL_AUTH_JWT`, which contains the JWT issued by your OIDC IDP.
 
 
 <a id="nestedatt--auth--universal"></a>


### PR DESCRIPTION
It wasn't immediately clear how to use the OIDC authentication method from the [provider documentation](https://registry.terraform.io/providers/Infisical/infisical/latest/docs#nested-schema-for-authoidc). Currently, you need to read the source code to uncover the environment variable that is needed.