### PR TITLE
feat(infisical-project-group): link group by name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.10.4"
       - run: go generate ./...
       - name: git diff
         run: |

--- a/docs/resources/project_group.md
+++ b/docs/resources/project_group.md
@@ -35,7 +35,10 @@ resource "infisical_project" "example" {
 
 resource "infisical_project_group" "group" {
   project_id = infisical_project.example.id
+
+  # Either group_id or group_name is required.
   group_id   = "<>"
+  group_name = "<>"
   roles = [
     {
       role_slug                   = "admin",
@@ -55,9 +58,13 @@ resource "infisical_project_group" "group" {
 
 ### Required
 
-- `group_id` (String) The id of the group.
 - `project_id` (String) The id of the project.
 - `roles` (Attributes Set) The roles assigned to the project group (see [below for nested schema](#nestedatt--roles))
+
+### Optional
+
+- `group_id` (String) The id of the group.
+- `group_name` (String) The name of the group.
 
 ### Read-Only
 

--- a/examples/resources/infisical_project_group/resource.tf
+++ b/examples/resources/infisical_project_group/resource.tf
@@ -20,7 +20,10 @@ resource "infisical_project" "example" {
 
 resource "infisical_project_group" "group" {
   project_id = infisical_project.example.id
+
+  # Either group_id or group_name is required.
   group_id   = "<>"
+  group_name = "<>"
   roles = [
     {
       role_slug                   = "admin",

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -954,9 +954,9 @@ type CreateProjectGroupRequestRoles struct {
 }
 
 type CreateProjectGroupRequest struct {
-	ProjectId string                           `json:"projectId"`
-	GroupId   string                           `json:"groupId"`
-	Roles     []CreateProjectGroupRequestRoles `json:"roles"`
+	GroupIdOrName string
+	ProjectId     string                           `json:"projectId"`
+	Roles         []CreateProjectGroupRequestRoles `json:"roles"`
 }
 
 type CreateProjectGroupResponseMembers struct {

--- a/internal/client/project_group.go
+++ b/internal/client/project_group.go
@@ -12,7 +12,7 @@ func (client Client) CreateProjectGroup(request CreateProjectGroupRequest) (Crea
 		SetResult(&responseData).
 		SetHeader("User-Agent", USER_AGENT).
 		SetBody(request).
-		Post(fmt.Sprintf("api/v2/workspace/%s/groups/%s", request.ProjectId, request.GroupId))
+		Post(fmt.Sprintf("api/v2/workspace/%s/groups/%s", request.ProjectId, request.GroupIdOrName))
 
 	if err != nil {
 		return CreateProjectGroupResponse{}, fmt.Errorf("CallCreateProjectGroup: Unable to complete api request [err=%s]", err)

--- a/internal/provider/resource/project_group.go
+++ b/internal/provider/resource/project_group.go
@@ -363,6 +363,14 @@ func (r *ProjectGroupResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	if plan.GroupName != state.GroupName {
+		resp.Diagnostics.AddError(
+			"Unable to update project group",
+			fmt.Sprintf("Cannot change group name, previous group name: %s, new group name: %s", state.GroupName, plan.GroupName),
+		)
+		return
+	}
+
 	var roles []infisical.UpdateProjectGroupRequestRoles
 	var hasAtleastOnePermanentRole bool
 	for _, el := range plan.Roles {

--- a/internal/provider/resource/project_group.go
+++ b/internal/provider/resource/project_group.go
@@ -33,6 +33,7 @@ type ProjectGroupResource struct {
 type ProjectGroupResourceModel struct {
 	ProjectID    types.String       `tfsdk:"project_id"`
 	GroupID      types.String       `tfsdk:"group_id"`
+	GroupName    types.String       `tfsdk:"group_name"`
 	Roles        []ProjectGroupRole `tfsdk:"roles"`
 	MembershipID types.String       `tfsdk:"membership_id"`
 }
@@ -59,8 +60,14 @@ func (r *ProjectGroupResource) Schema(_ context.Context, _ resource.SchemaReques
 				Required:    true,
 			},
 			"group_id": schema.StringAttribute{
-				Description: "The id of the group.",
-				Required:    true,
+				Description:   "The id of the group.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"group_name": schema.StringAttribute{
+				Description: "The name of the group.",
+				Optional:    true,
 			},
 			"membership_id": schema.StringAttribute{
 				Description:   "The membership Id of the project group",
@@ -133,6 +140,22 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	if plan.GroupID.ValueString() == "" && plan.GroupName.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Unable to create project group",
+			"Must provide either group_id or group_name",
+		)
+		return
+	}
+
+	if plan.GroupID.ValueString() != "" && plan.GroupName.ValueString() != "" {
+		resp.Diagnostics.AddError(
+			"Unable to create project group",
+			"Must provide either group_id or group_name, not both",
+		)
+		return
+	}
+
 	var roles []infisical.CreateProjectGroupRequestRoles
 	var hasAtleastOnePermanentRole bool
 	for _, el := range plan.Roles {
@@ -187,11 +210,18 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	projectGroupResponse, err := r.client.CreateProjectGroup(infisical.CreateProjectGroupRequest{
+	request := infisical.CreateProjectGroupRequest{
 		ProjectId: plan.ProjectID.ValueString(),
-		GroupId:   plan.GroupID.ValueString(),
 		Roles:     roles,
-	})
+	}
+
+	if plan.GroupID.ValueString() != "" {
+		request.GroupIdOrName = plan.GroupID.ValueString()
+	} else {
+		request.GroupIdOrName = plan.GroupName.ValueString()
+	}
+
+	projectGroupResponse, err := r.client.CreateProjectGroup(request)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -202,14 +232,7 @@ func (r *ProjectGroupResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	plan.MembershipID = types.StringValue(projectGroupResponse.Membership.ID)
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error fetching group details",
-			"Couldn't find group in project, unexpected error: "+err.Error(),
-		)
-		return
-	}
+	plan.GroupID = types.StringValue(projectGroupResponse.Membership.GroupID)
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
This PR introduces support for adding groups to projects by group name instead of just group ID. This is now possible because group names are unique within organizations.

Note, this PR depends on https://github.com/Infisical/infisical/pull/2997.