### PR TITLE
feat(project-resource): project description

### DIFF
--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 

--- a/docs/data-sources/projects.md
+++ b/docs/data-sources/projects.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_projects" "test-project" {

--- a/docs/data-sources/secret_tag.md
+++ b/docs/data-sources/secret_tag.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_secret_tag" "terraform" {

--- a/docs/data-sources/secrets.md
+++ b/docs/data-sources/secrets.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<universal-auth-client-id>"
-  client_secret = "<universal-auth-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_secrets" "common_secrets" {

--- a/docs/ephemeral-resources/secret.md
+++ b/docs/ephemeral-resources/secret.md
@@ -27,9 +27,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 ephemeral "infisical_secret" "postgres_username" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 ```
 

--- a/docs/resources/access_approval_policy.md
+++ b/docs/resources/access_approval_policy.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/identity.md
+++ b/docs/resources/identity.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 # universal authentication identity

--- a/docs/resources/identity_oidc_auth.md
+++ b/docs/resources/identity_oidc_auth.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/integration_aws_parameter_store.md
+++ b/docs/resources/integration_aws_parameter_store.md
@@ -23,11 +23,14 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
-
 
 resource "infisical_integration_aws_parameter_store" "parameter-store-integration" {
   project_id  = "<project-id>"

--- a/docs/resources/integration_aws_secrets_manager.md
+++ b/docs/resources/integration_aws_secrets_manager.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_integration_aws_secrets_manager" "secrets-manager-integration" {

--- a/docs/resources/integration_circleci.md
+++ b/docs/resources/integration_circleci.md
@@ -23,11 +23,14 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
-
 
 resource "infisical_integration_circleci" "circleci-integration" {
   project_id  = "225393b9-e3d6-424f-9df3-22c3cdeb97c9"

--- a/docs/resources/integration_databricks.md
+++ b/docs/resources/integration_databricks.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_integration_databricks" "db-integration" {

--- a/docs/resources/integration_gcp_secret_manager.md
+++ b/docs/resources/integration_gcp_secret_manager.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 variable "service_account_json" {

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -23,19 +23,25 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "gcp-project" {
-  name = "GCP Project"
-  slug = "gcp-project"
+  name        = "GCP Project"
+  slug        = "gcp-project"
+  description = "This is a GCP project"
 }
 
 resource "infisical_project" "aws-project" {
-  name = "AWS Project"
-  slug = "aws-project"
+  name        = "AWS Project"
+  slug        = "aws-project"
+  description = "This is an AWS project"
 }
 
 resource "infisical_project" "azure-project" {
@@ -51,6 +57,10 @@ resource "infisical_project" "azure-project" {
 
 - `name` (String) The name of the project
 - `slug` (String) The slug of the project
+
+### Optional
+
+- `description` (String) The description of the project
 
 ### Read-Only
 

--- a/docs/resources/project_environment.md
+++ b/docs/resources/project_environment.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/project_group.md
+++ b/docs/resources/project_group.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/project_identity.md
+++ b/docs/resources/project_identity.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/project_identity_specific_privilege.md
+++ b/docs/resources/project_identity_specific_privilege.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_secret" "mongo_secret" {

--- a/docs/resources/secret_approval_policy.md
+++ b/docs/resources/secret_approval_policy.md
@@ -23,9 +23,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/data-sources/infisical_groups/data-source.tf
+++ b/examples/data-sources/infisical_groups/data-source.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 

--- a/examples/data-sources/infisical_projects/data-source.tf
+++ b/examples/data-sources/infisical_projects/data-source.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_projects" "test-project" {

--- a/examples/data-sources/infisical_secret_folders/datasource.tf
+++ b/examples/data-sources/infisical_secret_folders/datasource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 

--- a/examples/data-sources/infisical_secret_tag/data-source.tf
+++ b/examples/data-sources/infisical_secret_tag/data-source.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_secret_tag" "terraform" {

--- a/examples/data-sources/infisical_secrets/data-source.tf
+++ b/examples/data-sources/infisical_secrets/data-source.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<universal-auth-client-id>"
-  client_secret = "<universal-auth-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 data "infisical_secrets" "common_secrets" {

--- a/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
@@ -12,9 +12,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 ephemeral "infisical_secret" "postgres_username" {

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,7 +8,11 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }

--- a/examples/resources/infisical_access_approval_policy/resource.tf
+++ b/examples/resources/infisical_access_approval_policy/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_identity/resource.tf
+++ b/examples/resources/infisical_identity/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 # universal authentication identity

--- a/examples/resources/infisical_identity_oidc_auth/resource.tf
+++ b/examples/resources/infisical_identity_oidc_auth/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_import_secret/infisical_import_secret.tf
+++ b/examples/resources/infisical_import_secret/infisical_import_secret.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_secret_import" "custom-import" {

--- a/examples/resources/infisical_integration_aws_parameter_store/resource.tf
+++ b/examples/resources/infisical_integration_aws_parameter_store/resource.tf
@@ -8,11 +8,14 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
-
 
 resource "infisical_integration_aws_parameter_store" "parameter-store-integration" {
   project_id  = "<project-id>"

--- a/examples/resources/infisical_integration_aws_secrets_manager/resource.tf
+++ b/examples/resources/infisical_integration_aws_secrets_manager/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_integration_aws_secrets_manager" "secrets-manager-integration" {

--- a/examples/resources/infisical_integration_circleci/resource.tf
+++ b/examples/resources/infisical_integration_circleci/resource.tf
@@ -8,11 +8,14 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
-
 
 resource "infisical_integration_circleci" "circleci-integration" {
   project_id  = "225393b9-e3d6-424f-9df3-22c3cdeb97c9"

--- a/examples/resources/infisical_integration_databricks/resource.tf
+++ b/examples/resources/infisical_integration_databricks/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_integration_databricks" "db-integration" {

--- a/examples/resources/infisical_integration_gcp_secret_manager/resource.tf
+++ b/examples/resources/infisical_integration_gcp_secret_manager/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 variable "service_account_json" {

--- a/examples/resources/infisical_project/resource.tf
+++ b/examples/resources/infisical_project/resource.tf
@@ -8,19 +8,25 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<machine-identity-client-id>"
-  client_secret = "<machine-identity-client-secret>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "gcp-project" {
-  name = "GCP Project"
-  slug = "gcp-project"
+  name        = "GCP Project"
+  slug        = "gcp-project"
+  description = "This is a GCP project"
 }
 
 resource "infisical_project" "aws-project" {
-  name = "AWS Project"
-  slug = "aws-project"
+  name        = "AWS Project"
+  slug        = "aws-project"
+  description = "This is an AWS project"
 }
 
 resource "infisical_project" "azure-project" {

--- a/examples/resources/infisical_project_environment/resource.tf
+++ b/examples/resources/infisical_project_environment/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_project_group/resource.tf
+++ b/examples/resources/infisical_project_group/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_project_identity/resource.tf
+++ b/examples/resources/infisical_project_identity/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_project_identity_specific_privilege/resource.tf
+++ b/examples/resources/infisical_project_identity_specific_privilege/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_project_role/resource.tf
+++ b/examples/resources/infisical_project_role/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_project_user/resource.tf
+++ b/examples/resources/infisical_project_user/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_secret/resource.tf
+++ b/examples/resources/infisical_secret/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_secret" "mongo_secret" {

--- a/examples/resources/infisical_secret_approval_policy/resource.tf
+++ b/examples/resources/infisical_secret_approval_policy/resource.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_project" "example" {

--- a/examples/resources/infisical_secret_folder/infisical_secret_folder.tf
+++ b/examples/resources/infisical_secret_folder/infisical_secret_folder.tf
@@ -8,9 +8,13 @@ terraform {
 }
 
 provider "infisical" {
-  host          = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
-  client_id     = "<>"
-  client_secret = "<>"
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  auth = {
+    universal = {
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
+    }
+  }
 }
 
 resource "infisical_secret_folder" "folder-1" {

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -42,6 +42,7 @@ type EncryptedSecretV3 struct {
 type Project struct {
 	ID                 string    `json:"id"`
 	Name               string    `json:"name"`
+	Description        string    `json:"description"`
 	Slug               string    `json:"slug"`
 	AutoCapitalization bool      `json:"autoCapitalization"`
 	OrgID              string    `json:"orgId"`
@@ -253,6 +254,7 @@ type ProjectRole struct {
 type ProjectWithEnvironments struct {
 	ID                 string               `json:"id"`
 	Name               string               `json:"name"`
+	Description        string               `json:"description"`
 	Slug               string               `json:"slug"`
 	AutoCapitalization bool                 `json:"autoCapitalization"`
 	OrgID              string               `json:"orgId"`
@@ -559,9 +561,10 @@ type UpdateRawSecretByNameV3Request struct {
 }
 
 type CreateProjectRequest struct {
-	ProjectName      string `json:"projectName"`
-	Slug             string `json:"slug"`
-	OrganizationSlug string `json:"organizationSlug"`
+	ProjectName        string `json:"projectName"`
+	ProjectDescription string `json:"projectDescription,omitempty"`
+	Slug               string `json:"slug"`
+	OrganizationSlug   string `json:"organizationSlug"`
 }
 
 type DeleteProjectRequest struct {
@@ -577,8 +580,9 @@ type GetProjectByIdRequest struct {
 }
 
 type UpdateProjectRequest struct {
-	Slug        string `json:"slug"`
-	ProjectName string `json:"name"`
+	Slug               string `json:"slug"`
+	ProjectName        string `json:"name"`
+	ProjectDescription string `json:"description"`
 }
 
 type InviteUsersToProjectRequest struct {


### PR DESCRIPTION
This PR adds project description support to the pre-existing project resource.

Additionally I've also updated our examples and docs to properly reflect the new auth structure. The plain `client_id` and `client_secret` combo very old and should be considered legacy.