### PR TITLE
fix: add length check to project user create

### DIFF
--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -254,7 +254,7 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 	if len(invitedUser) == 0 {
 		resp.Diagnostics.AddError(
 			"Error inviting user",
-			"Couldn't create project user to Infiscial, no invite was created. Is the user already in the project?",
+			"Could not add user to project. No invite was sent, is the user already in the project?",
 		)
 		return
 	}

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -251,6 +251,14 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	if len(invitedUser) == 0 {
+		resp.Diagnostics.AddError(
+			"Error inviting user",
+			"Couldn't create project user to Infiscial, no invite was created. Is the user already in the project?",
+		)
+		return
+	}
+
 	_, err = r.client.UpdateProjectUser(infisical.UpdateProjectUserRequest{
 		ProjectID:    plan.ProjectID.ValueString(),
 		MembershipID: invitedUser[0].ID,


### PR DESCRIPTION
This PR fixes a provider crash caused by trying to invite a user to a project whom is already invited to the project.

### New error
```
│ Error: Error inviting user
│ 
│   with infisical_project_user.test-user,
│   on resource.tf line 20, in resource "infisical_project_user" "test-user":
│   20: resource "infisical_project_user" "test-user" {
│ 
│ Couldn't create project user to Infiscial, no invite was created. Is the user already in the project?
```

### Old error:
```
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
╵

Stack trace from the terraform-provider-infisical plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 66 [running]:
terraform-provider-infisical/internal/provider/resource.(*ProjectUserResource).Create(0x14000408050, {0x1055f1fd8, 0x14000010c60}, {{{{0x1055f7310, 0x140003bcae0}, {0x1054c0680, 0x14000011ec0}}, {0x1055f9c88, 0x1400016a910}}, {{{0x1055f7310, ...}, ...}, ...}, ...}, ...)
        /Users/danielhougaard/Documents/git/terraform-provider-infisical/internal/provider/resource/project_user_resource.go:264 +0xec4
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).CreateResource(0x1400017f448, {0x1055f1fd8, 0x14000010c60}, 0x140003bb528, 0x140003bb500)
        /Users/danielhougaard/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_createresource.go:101 +0x400
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0x1400017f448, {0x1055f1fd8, 0x14000010c60}, 0x14000014410, 0x140003bb620)
        /Users/danielhougaard/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_applyresourcechange.go:57 +0x380
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0x1400017f448, {0x1055f1fd8?, 0x14000010b70?}, 0x14000014370)
        /Users/danielhougaard/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/proto6server/server_applyresourcechange.go:55 +0x2e0
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0x1400021afa0, {0x1055f1fd8?, 0x140000101e0?}, 0x14000450070)
        /Users/danielhougaard/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:865 +0x2a8
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x1055c51e0, 0x1400021afa0}, {0x1055f1fd8, 0x140000101e0}, 0x14000258000, 0x0)
        /Users/danielhougaard/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:611 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001a1000, {0x1055f1fd8, 0x14000010150}, {0x1055f8540, 0x14000480000}, 0x14000210000, 0x14000382360, 0x105b86398, 0x0)
        /Users/danielhougaard/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
google.golang.org/grpc.(*Server).handleStream(0x140001a1000, {0x1055f8540, 0x14000480000}, 0x14000210000)
        /Users/danielhougaard/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/danielhougaard/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 36
        /Users/danielhougaard/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c

Error: The terraform-provider-infisical plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```