### PR TITLE
feat(project-resource): template support

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -61,6 +61,7 @@ resource "infisical_project" "azure-project" {
 ### Optional
 
 - `description` (String) The description of the project
+- `template_name` (String) The name of the template to use for the project
 
 ### Read-Only
 

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -3,12 +3,12 @@
 page_title: "infisical_project_user Resource - terraform-provider-infisical"
 subcategory: ""
 description: |-
-  Create project users & save to Infisical. Only Machine Identity authentication is supported for this data source
+  Create project users & save to Infisical. Only Machine Identity authentication is supported for this resource
 ---
 
 # infisical_project_user (Resource)
 
-Create project users & save to Infisical. Only Machine Identity authentication is supported for this data source
+Create project users & save to Infisical. Only Machine Identity authentication is supported for this resource
 
 ## Example Usage
 

--- a/examples/resources/infisical_project/resource.tf
+++ b/examples/resources/infisical_project/resource.tf
@@ -2,35 +2,36 @@ terraform {
   required_providers {
     infisical = {
       # version = <latest version>
-      source = "hashicorp.com/edu/infisical"
+      source = "infisical/infisical"
     }
   }
 }
 
 provider "infisical" {
-  host = "http://localhost:8080" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
   auth = {
     universal = {
-      client_id     = "f66716d8-874d-4456-9f59-5b5185e2518c"
-      client_secret = "18a880b034e5d367065047972c021212707054bb89ce61d24f42e853ed50b6bb"
+      client_id     = "<machine-identity-client-id>"
+      client_secret = "<machine-identity-client-secret>"
     }
   }
 }
 
-
-resource "infisical_project" "te11st" {
-  description   = ""
-  name          = "aasdaaaasda"
-  template_name = "test"
-  slug          = "aaasdasda-aaaaboqj"
+resource "infisical_project" "gcp-project" {
+  name        = "GCP Project"
+  slug        = "gcp-project"
+  description = "This is a GCP project"
 }
 
-resource "infisical_project_user" "test-user" {
-  project_id = infisical_project.te11st.id
-  username   = "dani250g@hotmail.com"
-  roles = [
-    {
-      role_slug = "admin"
-    }
-  ]
+resource "infisical_project" "aws-project" {
+  name        = "AWS Project"
+  slug        = "aws-project"
+  description = "This is an AWS project"
 }
+
+resource "infisical_project" "azure-project" {
+  name = "Azure Project"
+  slug = "azure-project"
+}
+
+

--- a/examples/resources/infisical_project/resource.tf
+++ b/examples/resources/infisical_project/resource.tf
@@ -2,36 +2,35 @@ terraform {
   required_providers {
     infisical = {
       # version = <latest version>
-      source = "infisical/infisical"
+      source = "hashicorp.com/edu/infisical"
     }
   }
 }
 
 provider "infisical" {
-  host = "https://app.infisical.com" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
+  host = "http://localhost:8080" # Only required if using self hosted instance of Infisical, default is https://app.infisical.com
   auth = {
     universal = {
-      client_id     = "<machine-identity-client-id>"
-      client_secret = "<machine-identity-client-secret>"
+      client_id     = "f66716d8-874d-4456-9f59-5b5185e2518c"
+      client_secret = "18a880b034e5d367065047972c021212707054bb89ce61d24f42e853ed50b6bb"
     }
   }
 }
 
-resource "infisical_project" "gcp-project" {
-  name        = "GCP Project"
-  slug        = "gcp-project"
-  description = "This is a GCP project"
+
+resource "infisical_project" "te11st" {
+  description   = ""
+  name          = "aasdaaaasda"
+  template_name = "test"
+  slug          = "aaasdasda-aaaaboqj"
 }
 
-resource "infisical_project" "aws-project" {
-  name        = "AWS Project"
-  slug        = "aws-project"
-  description = "This is an AWS project"
+resource "infisical_project_user" "test-user" {
+  project_id = infisical_project.te11st.id
+  username   = "dani250g@hotmail.com"
+  roles = [
+    {
+      role_slug = "admin"
+    }
+  ]
 }
-
-resource "infisical_project" "azure-project" {
-  name = "Azure Project"
-  slug = "azure-project"
-}
-
-

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -592,6 +592,7 @@ type CreateProjectRequest struct {
 	ProjectDescription string `json:"projectDescription,omitempty"`
 	Slug               string `json:"slug"`
 	OrganizationSlug   string `json:"organizationSlug"`
+	Template           string `json:"template,omitempty"`
 }
 
 type DeleteProjectRequest struct {

--- a/internal/provider/resource/project_resource.go
+++ b/internal/provider/resource/project_resource.go
@@ -34,11 +34,12 @@ type projectResource struct {
 
 // projectResourceSourceModel describes the data source data model.
 type projectResourceModel struct {
-	Slug        types.String `tfsdk:"slug"`
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	LastUpdated types.String `tfsdk:"last_updated"`
+	Slug         types.String `tfsdk:"slug"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Description  types.String `tfsdk:"description"`
+	LastUpdated  types.String `tfsdk:"last_updated"`
+	TemplateName types.String `tfsdk:"template_name"`
 }
 
 // Metadata returns the resource type name.
@@ -66,6 +67,12 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "The description of the project",
 				Optional:    true,
 			},
+			"template_name": schema.StringAttribute{
+				Description:   "The name of the template to use for the project",
+				Optional:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+
 			"id": schema.StringAttribute{
 				Description:   "The ID of the project",
 				Computed:      true,
@@ -121,6 +128,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		ProjectName:        plan.Name.ValueString(),
 		ProjectDescription: plan.Description.ValueString(),
 		Slug:               plan.Slug.ValueString(),
+		Template:           plan.TemplateName.ValueString(),
 	})
 
 	if err != nil {

--- a/internal/provider/resource/project_resource.go
+++ b/internal/provider/resource/project_resource.go
@@ -68,9 +68,8 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 			},
 			"template_name": schema.StringAttribute{
-				Description:   "The name of the template to use for the project",
-				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Description: "The name of the template to use for the project",
+				Optional:    true,
 			},
 
 			"id": schema.StringAttribute{
@@ -219,6 +218,14 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.TemplateName != plan.TemplateName {
+		resp.Diagnostics.AddError(
+			"Unable to update project",
+			"Template name cannot be updated",
+		)
 		return
 	}
 

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -68,7 +68,7 @@ func (r *ProjectUserResource) Metadata(_ context.Context, req resource.MetadataR
 // Schema defines the schema for the resource.
 func (r *ProjectUserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Create project users & save to Infisical. Only Machine Identity authentication is supported for this data source",
+		Description: "Create project users & save to Infisical. Only Machine Identity authentication is supported for this resource",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Description:   "The id of the project",

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -71,9 +71,8 @@ func (r *ProjectUserResource) Schema(_ context.Context, _ resource.SchemaRequest
 		Description: "Create project users & save to Infisical. Only Machine Identity authentication is supported for this resource",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
-				Description:   "The id of the project",
-				Required:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Description: "The id of the project",
+				Required:    true,
 			},
 			"username": schema.StringAttribute{
 				Description: "The usename of the user. By default its the email",
@@ -443,6 +442,14 @@ func (r *ProjectUserResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError(
 			"Unable to update project user",
 			fmt.Sprintf("Cannot change username, previous username: %s, new username: %s", state.Username, plan.Username),
+		)
+		return
+	}
+
+	if state.ProjectID != plan.ProjectID {
+		resp.Diagnostics.AddError(
+			"Unable to update project user",
+			fmt.Sprintf("Cannot change project_id, previous project_id: %s, new project_id: %s", state.ProjectID, plan.ProjectID),
 		)
 		return
 	}

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -71,8 +71,9 @@ func (r *ProjectUserResource) Schema(_ context.Context, _ resource.SchemaRequest
 		Description: "Create project users & save to Infisical. Only Machine Identity authentication is supported for this data source",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
-				Description: "The id of the project",
-				Required:    true,
+				Description:   "The id of the project",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"username": schema.StringAttribute{
 				Description: "The usename of the user. By default its the email",

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -71,8 +71,9 @@ func (r *ProjectUserResource) Schema(_ context.Context, _ resource.SchemaRequest
 		Description: "Create project users & save to Infisical. Only Machine Identity authentication is supported for this resource",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
-				Description: "The id of the project",
-				Required:    true,
+				Description:   "The id of the project",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"username": schema.StringAttribute{
 				Description: "The usename of the user. By default its the email",
@@ -442,14 +443,6 @@ func (r *ProjectUserResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError(
 			"Unable to update project user",
 			fmt.Sprintf("Cannot change username, previous username: %s, new username: %s", state.Username, plan.Username),
-		)
-		return
-	}
-
-	if state.ProjectID != plan.ProjectID {
-		resp.Diagnostics.AddError(
-			"Unable to update project user",
-			fmt.Sprintf("Cannot change project_id, previous project_id: %s, new project_id: %s", state.ProjectID, plan.ProjectID),
 		)
 		return
 	}


### PR DESCRIPTION
This PR adds templating support for projects created via. Terraform. It's only supported on the initial create, since there's no way to change the template once a project is created. We use a RequireReplace modifier to insure that the template isn't changed.

Additionally, I added a RequireReplace on the project_user resource's projectId field. We should be replacing memberships if the project ID changes (such as if the project gets replaced)