### PR TITLE
feat(oidc-auth): claim metadata mapping

### DIFF
--- a/docs/resources/identity_oidc_auth.md
+++ b/docs/resources/identity_oidc_auth.md
@@ -70,7 +70,7 @@ resource "infisical_identity_oidc_auth" "oidc-auth" {
 - `bound_audiences` (List of String) The comma-separated list of intended recipients.
 - `bound_claims` (Map of String) The attributes that should be present in the JWT for it to be valid. The provided values can be a glob pattern.
 - `bound_subject` (String) The expected principal that is the subject of the JWT.
-- `claim_metadata_mapping` (Map of String) The attributes that should be present in the permission metadata from the JWT.
+- `claim_metadata_mapping` (Map of String) Map OIDC token claims to metadata fields. Example: {"role": "token.groups"}, this would become identity.metadata.oidc.claims.role
 - `oidc_ca_certificate` (String) The PEM-encoded CA cert for establishing secure communication with the Identity Provider endpoints
 
 ### Read-Only

--- a/docs/resources/identity_oidc_auth.md
+++ b/docs/resources/identity_oidc_auth.md
@@ -70,6 +70,7 @@ resource "infisical_identity_oidc_auth" "oidc-auth" {
 - `bound_audiences` (List of String) The comma-separated list of intended recipients.
 - `bound_claims` (Map of String) The attributes that should be present in the JWT for it to be valid. The provided values can be a glob pattern.
 - `bound_subject` (String) The expected principal that is the subject of the JWT.
+- `claim_metadata_mapping` (Map of String) The attributes that should be present in the permission metadata from the JWT.
 - `oidc_ca_certificate` (String) The PEM-encoded CA cert for establishing secure communication with the Identity Provider endpoints
 
 ### Read-Only

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -205,6 +205,7 @@ type IdentityOidcAuth struct {
 	BoundIssuer             string                  `json:"boundIssuer"`
 	BoundAudiences          string                  `json:"boundAudiences"`
 	BoundClaims             map[string]string       `json:"boundClaims"`
+	ClaimMetadataMapping    map[string]string       `json:"claimMetadataMapping"`
 	BoundSubject            string                  `json:"boundSubject"`
 	CACERT                  string                  `json:"caCert"`
 }
@@ -1542,6 +1543,7 @@ type CreateIdentityOidcAuthRequest struct {
 	BoundIssuer             string                         `json:"boundIssuer"`
 	BoundAudiences          string                         `json:"boundAudiences"`
 	BoundClaims             map[string]string              `json:"boundClaims"`
+	ClaimMetadataMapping    map[string]string              `json:"claimMetadataMapping"`
 	BoundSubject            string                         `json:"boundSubject"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
 	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`
@@ -1556,6 +1558,7 @@ type UpdateIdentityOidcAuthRequest struct {
 	BoundIssuer             string                         `json:"boundIssuer"`
 	BoundAudiences          string                         `json:"boundAudiences"`
 	BoundClaims             map[string]string              `json:"boundClaims"`
+	ClaimMetadataMapping    map[string]string              `json:"claimMetadataMapping"`
 	BoundSubject            string                         `json:"boundSubject"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
 	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`

--- a/internal/provider/resource/identity_oidc_auth.go
+++ b/internal/provider/resource/identity_oidc_auth.go
@@ -101,7 +101,7 @@ func (r *IdentityOidcAuthResource) Schema(_ context.Context, _ resource.SchemaRe
 			},
 
 			"claim_metadata_mapping": schema.MapAttribute{
-				Description: "The attributes that should be present in the permission metadata from the JWT.",
+				Description: "Map OIDC token claims to metadata fields. Example: {\"role\": \"token.groups\"}, this would become identity.metadata.oidc.claims.role",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/internal/provider/resource/identity_oidc_auth.go
+++ b/internal/provider/resource/identity_oidc_auth.go
@@ -42,6 +42,7 @@ type IdentityOidcAuthResourceModel struct {
 	BoundIssuer             types.String `tfsdk:"bound_issuer"`
 	BoundAudiences          types.List   `tfsdk:"bound_audiences"`
 	BoundClaims             types.Map    `tfsdk:"bound_claims"`
+	ClaimMetadataMapping    types.Map    `tfsdk:"claim_metadata_mapping"`
 	BoundSubject            types.String `tfsdk:"bound_subject"`
 	AccessTokenTrustedIps   types.List   `tfsdk:"access_token_trusted_ips"`
 	AccessTokenTTL          types.Int64  `tfsdk:"access_token_ttl"`
@@ -96,6 +97,16 @@ func (r *IdentityOidcAuthResource) Schema(_ context.Context, _ resource.SchemaRe
 				PlanModifiers: []planmodifier.Map{
 					mapplanmodifier.UseStateForUnknown(),
 					pkg.CommaSpaceMapModifier{},
+				},
+			},
+
+			"claim_metadata_mapping": schema.MapAttribute{
+				Description: "The attributes that should be present in the permission metadata from the JWT.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"bound_subject": schema.StringAttribute{
@@ -178,6 +189,7 @@ func updateOidcAuthStateByApi(ctx context.Context, diagnose diag.Diagnostics, pl
 	plan.CaCertificate = types.StringValue(newIdentityOidcAuth.CACERT)
 
 	boundClaimsElements := make(map[string]attr.Value)
+	claimMetadataMappingElements := make(map[string]attr.Value)
 	for key, value := range newIdentityOidcAuth.BoundClaims {
 		// Check plan format
 		useSpaces := false
@@ -203,13 +215,24 @@ func updateOidcAuthStateByApi(ctx context.Context, diagnose diag.Diagnostics, pl
 		}
 	}
 
+	for key, value := range newIdentityOidcAuth.ClaimMetadataMapping {
+		claimMetadataMappingElements[key] = types.StringValue(value)
+	}
+
 	boundClaimsMapValue, diags := types.MapValue(types.StringType, boundClaimsElements)
 	diagnose.Append(diags...)
 	if diagnose.HasError() {
 		return
 	}
 
+	claimMetadataMappingMapValue, diags := types.MapValue(types.StringType, claimMetadataMappingElements)
+	diagnose.Append(diags...)
+	if diagnose.HasError() {
+		return
+	}
+
 	plan.BoundClaims = boundClaimsMapValue
+	plan.ClaimMetadataMapping = claimMetadataMappingMapValue
 
 	plan.BoundAudiences, diags = types.ListValueFrom(ctx, types.StringType, infisicalstrings.StringSplitAndTrim(newIdentityOidcAuth.BoundAudiences, ","))
 	diagnose.Append(diags...)
@@ -278,6 +301,13 @@ func (r *IdentityOidcAuthResource) Create(ctx context.Context, req resource.Crea
 		}
 	}
 
+	claimMetadataMappingMap := make(map[string]string)
+	for key, value := range plan.ClaimMetadataMapping.Elements() {
+		if strVal, ok := value.(types.String); ok {
+			claimMetadataMappingMap[key] = strVal.ValueString()
+		}
+	}
+
 	newIdentityOidcAuth, err := r.client.CreateIdentityOidcAuth(infisical.CreateIdentityOidcAuthRequest{
 		IdentityID:              plan.IdentityID.ValueString(),
 		AccessTokenTTL:          plan.AccessTokenTTL.ValueInt64(),
@@ -289,6 +319,7 @@ func (r *IdentityOidcAuthResource) Create(ctx context.Context, req resource.Crea
 		BoundIssuer:             plan.BoundIssuer.ValueString(),
 		BoundSubject:            plan.BoundSubject.ValueString(),
 		BoundClaims:             boundClaimsMap,
+		ClaimMetadataMapping:    claimMetadataMappingMap,
 		CACERT:                  plan.CaCertificate.ValueString(),
 	})
 
@@ -395,6 +426,13 @@ func (r *IdentityOidcAuthResource) Update(ctx context.Context, req resource.Upda
 		}
 	}
 
+	claimMetadataMappingMap := make(map[string]string)
+	for key, value := range plan.ClaimMetadataMapping.Elements() {
+		if strVal, ok := value.(types.String); ok {
+			claimMetadataMappingMap[key] = strVal.ValueString()
+		}
+	}
+
 	updatedIdentityOidcAuth, err := r.client.UpdateIdentityOidcAuth(infisical.UpdateIdentityOidcAuthRequest{
 		IdentityID:              plan.IdentityID.ValueString(),
 		AccessTokenTTL:          plan.AccessTokenTTL.ValueInt64(),
@@ -406,6 +444,7 @@ func (r *IdentityOidcAuthResource) Update(ctx context.Context, req resource.Upda
 		BoundIssuer:             plan.BoundIssuer.ValueString(),
 		BoundSubject:            plan.BoundSubject.ValueString(),
 		BoundClaims:             boundClaimsMap,
+		ClaimMetadataMapping:    claimMetadataMappingMap,
 		CACERT:                  plan.CaCertificate.ValueString(),
 	})
 


### PR DESCRIPTION
This PR adds support for OIDC auth claim metadata mapping, which was recently introduced to OIDC auth.