### PR TITLE
misc: added missing terraform setup step in crossplane release

### DIFF
--- a/.github/workflows/release-crossplane.yml
+++ b/.github/workflows/release-crossplane.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
-
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.10.4"
       - name: Replace resource files for Crossplane
         run: |
           chmod +x ./scripts/prepare-crossplane.sh
           ./scripts/prepare-crossplane.sh
-
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
         id: import_gpg


### PR DESCRIPTION
This addresses the following build error
![image](https://github.com/user-attachments/assets/6eab65d3-c1cd-4064-be18-984e89207194)
