### PR TITLE
misc: add skip validate for crossplane release

### DIFF
--- a/.github/workflows/release-crossplane.yml
+++ b/.github/workflows/release-crossplane.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: v1.26.2-pro
-          args: release --clean --config .goreleaser-crossplane.yml
+          args: release --clean --config .goreleaser-crossplane.yml --skip-validate
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR ensures that crossplane release works even when some changes are not present in git (because we force the files)