### PR TITLE
feat(secret-approval-policy): add allow self approvals support

### DIFF
--- a/docs/resources/secret_approval_policy.md
+++ b/docs/resources/secret_approval_policy.md
@@ -69,6 +69,7 @@ resource "infisical_secret_approval_policy" "prod-policy" {
 
 ### Optional
 
+- `allow_self_approval` (Boolean) Whether to allow the  approvers to approve their own changes
 - `enforcement_level` (String) The enforcement level of the policy. This can either be hard or soft
 - `name` (String) The name of the secret approval policy
 

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1741,14 +1741,15 @@ type SecretApprovalPolicyApprover struct {
 }
 
 type SecretApprovalPolicy struct {
-	ID                string                          `json:"id"`
-	ProjectID         string                          `json:"projectId"`
-	Name              string                          `json:"name"`
-	Environment       SecretApprovalPolicyEnvironment `json:"environment"`
-	SecretPath        string                          `json:"secretPath"`
-	Approvers         []SecretApprovalPolicyApprover  `json:"approvers"`
-	RequiredApprovals int64                           `json:"approvals"`
-	EnforcementLevel  string                          `json:"enforcementLevel"`
+	ID                   string                          `json:"id"`
+	ProjectID            string                          `json:"projectId"`
+	Name                 string                          `json:"name"`
+	Environment          SecretApprovalPolicyEnvironment `json:"environment"`
+	SecretPath           string                          `json:"secretPath"`
+	Approvers            []SecretApprovalPolicyApprover  `json:"approvers"`
+	RequiredApprovals    int64                           `json:"approvals"`
+	EnforcementLevel     string                          `json:"enforcementLevel"`
+	AllowedSelfApprovals bool                            `json:"allowedSelfApprovals"`
 }
 
 type CreateSecretApprovalPolicyApprover struct {
@@ -1758,13 +1759,14 @@ type CreateSecretApprovalPolicyApprover struct {
 }
 
 type CreateSecretApprovalPolicyRequest struct {
-	ProjectID         string                               `json:"workspaceId"`
-	Name              string                               `json:"name,omitempty"`
-	Environment       string                               `json:"environment"`
-	SecretPath        string                               `json:"secretPath"`
-	Approvers         []CreateSecretApprovalPolicyApprover `json:"approvers"`
-	RequiredApprovals int64                                `json:"approvals"`
-	EnforcementLevel  string                               `json:"enforcementLevel"`
+	ProjectID            string                               `json:"workspaceId"`
+	Name                 string                               `json:"name,omitempty"`
+	Environment          string                               `json:"environment"`
+	SecretPath           string                               `json:"secretPath"`
+	Approvers            []CreateSecretApprovalPolicyApprover `json:"approvers"`
+	RequiredApprovals    int64                                `json:"approvals"`
+	EnforcementLevel     string                               `json:"enforcementLevel"`
+	AllowedSelfApprovals bool                                 `json:"allowedSelfApprovals"`
 }
 
 type CreateSecretApprovalPolicyResponse struct {
@@ -1786,12 +1788,13 @@ type UpdateSecretApprovalPolicyApprover struct {
 }
 
 type UpdateSecretApprovalPolicyRequest struct {
-	ID                string
-	Name              string                               `json:"name"`
-	SecretPath        string                               `json:"secretPath"`
-	Approvers         []UpdateSecretApprovalPolicyApprover `json:"approvers"`
-	RequiredApprovals int64                                `json:"approvals"`
-	EnforcementLevel  string                               `json:"enforcementLevel"`
+	ID                   string
+	Name                 string                               `json:"name"`
+	SecretPath           string                               `json:"secretPath"`
+	Approvers            []UpdateSecretApprovalPolicyApprover `json:"approvers"`
+	RequiredApprovals    int64                                `json:"approvals"`
+	EnforcementLevel     string                               `json:"enforcementLevel"`
+	AllowedSelfApprovals bool                                 `json:"allowedSelfApprovals"`
 }
 
 type UpdateSecretApprovalPolicyResponse struct {


### PR DESCRIPTION
This PR adds support for allowing self approvals for secret policies in Terraform. It defaults to `true` which is inline with the current behavior.