### PR TITLE
feat(project_identity_resource): import support

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -82,6 +82,10 @@ type ProjectIdentity struct {
 		Id          string   `json:"id"`
 		AuthMethods []string `json:"authMethods"`
 	} `json:"identity"`
+	Project struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"project"`
 }
 
 type ProjectMemberRole struct {
@@ -713,6 +717,10 @@ type CreateProjectIdentityResponseMembers struct {
 type GetProjectIdentityByIDRequest struct {
 	ProjectID  string `json:"projectId"`
 	IdentityID string `json:"identityId"`
+}
+
+type GetProjectIdentityByMembershipIDRequest struct {
+	MembershipID string
 }
 
 type GetProjectIdentityByIDResponse struct {

--- a/internal/client/project_identity.go
+++ b/internal/client/project_identity.go
@@ -88,3 +88,26 @@ func (client Client) GetProjectIdentityByID(request GetProjectIdentityByIDReques
 
 	return responseData, nil
 }
+
+func (client Client) GetProjectIdentityByMembershipID(request GetProjectIdentityByMembershipIDRequest) (GetProjectIdentityByIDResponse, error) {
+	var responseData GetProjectIdentityByIDResponse
+	response, err := client.Config.HttpClient.
+		R().
+		SetResult(&responseData).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Get(fmt.Sprintf("api/v2/workspace/identity-memberships/%s", request.MembershipID))
+
+	if err != nil {
+		return GetProjectIdentityByIDResponse{}, fmt.Errorf("GetProjectIdentityByMembershipID: Unable to complete api request [err=%s]", err)
+	}
+
+	if response.IsError() {
+		if response.StatusCode() == http.StatusNotFound {
+			return GetProjectIdentityByIDResponse{}, ErrNotFound
+		}
+		return GetProjectIdentityByIDResponse{}, fmt.Errorf("GetProjectIdentityByMembershipID: Unsuccessful response. [response=%s]", response)
+	}
+
+	return responseData, nil
+}


### PR DESCRIPTION
This PR adds support for importing project identities by ID. This PR depends on https://github.com/Infisical/infisical/pull/3389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced project identity representation now includes additional project details (ID and name) for improved clarity.
  - Introduced a new capability to retrieve project identity information using membership IDs.
  - Added an import mechanism that seamlessly integrates project identity states based on membership information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->