### PR TITLE
feat(secret-syncs): add disable secret deletion support

### DIFF
--- a/docs/resources/secret_sync_aws_parameter_store.md
+++ b/docs/resources/secret_sync_aws_parameter_store.md
@@ -104,6 +104,7 @@ Required:
 Optional:
 
 - `aws_kms_key_id` (String) The AWS KMS key ID to use for encryption
+- `disable_secret_deletion` (Boolean) When set to true, Infisical will not remove secrets from AWS Parameter Store. Enable this option if you intend to manage some secrets manually outside of Infisical.
 - `sync_secret_metadata_as_tags` (Boolean) Whether to sync the secret metadata as tags
 - `tags` (Attributes Set) The tags to sync to the secret (see [below for nested schema](#nestedatt--sync_options--tags))
 

--- a/docs/resources/secret_sync_aws_secrets_manager.md
+++ b/docs/resources/secret_sync_aws_secrets_manager.md
@@ -109,6 +109,7 @@ Required:
 Optional:
 
 - `aws_kms_key_id` (String) The AWS KMS key ID to use for encryption
+- `disable_secret_deletion` (Boolean) When set to true, Infisical will not remove secrets from AWS Secrets Manager. Enable this option if you intend to manage some secrets manually outside of Infisical.
 - `sync_secret_metadata_as_tags` (Boolean) Whether to sync the secret metadata as tags. This is only supported for the 'one-to-one' mapping behavior.
 - `tags` (Attributes Set) The tags to sync to the secret (see [below for nested schema](#nestedatt--sync_options--tags))
 

--- a/docs/resources/secret_sync_azure_app_configuration.md
+++ b/docs/resources/secret_sync_azure_app_configuration.md
@@ -89,3 +89,7 @@ Optional:
 Required:
 
 - `initial_sync_behavior` (String) Specify how Infisical should resolve the initial sync to the destination. Supported options: overwrite-destination, import-prioritize-source, import-prioritize-destination
+
+Optional:
+
+- `disable_secret_deletion` (Boolean) When set to true, Infisical will not remove secrets from Azure App Configuration. Enable this option if you intend to manage some secrets manually outside of Infisical.

--- a/docs/resources/secret_sync_azure_key_vault.md
+++ b/docs/resources/secret_sync_azure_key_vault.md
@@ -85,3 +85,7 @@ Required:
 Required:
 
 - `initial_sync_behavior` (String) Specify how Infisical should resolve the initial sync to the destination. Supported options: overwrite-destination, import-prioritize-source, import-prioritize-destination
+
+Optional:
+
+- `disable_secret_deletion` (Boolean) When set to true, Infisical will not remove secrets from Azure Key Vault. Enable this option if you intend to manage some secrets manually outside of Infisical.

--- a/docs/resources/secret_sync_gcp_secret_manager.md
+++ b/docs/resources/secret_sync_gcp_secret_manager.md
@@ -98,3 +98,7 @@ Optional:
 Required:
 
 - `initial_sync_behavior` (String) Specify how Infisical should resolve the initial sync to the destination. Supported options: overwrite-destination, import-prioritize-source, import-prioritize-destination
+
+Optional:
+
+- `disable_secret_deletion` (Boolean) When set to true, Infisical will not remove secrets from GCP Secret Manager. Enable this option if you intend to manage some secrets manually outside of Infisical.

--- a/internal/provider/resource/secret_sync/secret_sync_aws_secrets_manager.go
+++ b/internal/provider/resource/secret_sync/secret_sync_aws_secrets_manager.go
@@ -29,6 +29,7 @@ type AwsSecretsManagerTagsModel struct {
 
 type SecretSyncAwsSecretsManagerSyncOptionsModel struct {
 	InitialSyncBehavior      types.String `tfsdk:"initial_sync_behavior"`
+	DisableSecretDeletion    types.Bool   `tfsdk:"disable_secret_deletion"`
 	KeyID                    types.String `tfsdk:"aws_kms_key_id"`
 	SyncSecretMetadataAsTags types.Bool   `tfsdk:"sync_secret_metadata_as_tags"`
 	Tags                     types.Set    `tfsdk:"tags"`
@@ -60,6 +61,12 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 			"initial_sync_behavior": schema.StringAttribute{
 				Required:    true,
 				Description: "Specify how Infisical should resolve the initial sync to the destination. Supported options: overwrite-destination, import-prioritize-source, import-prioritize-destination",
+			},
+			"disable_secret_deletion": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When set to true, Infisical will not remove secrets from AWS Secrets Manager. Enable this option if you intend to manage some secrets manually outside of Infisical.",
+				Default:     booldefault.StaticBool(false),
 			},
 			"aws_kms_key_id": schema.StringAttribute{
 				Optional:    true,
@@ -99,6 +106,7 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 			}
 
 			syncOptionsMap["initialSyncBehavior"] = syncOptions.InitialSyncBehavior.ValueString()
+			syncOptionsMap["disableSecretDeletion"] = syncOptions.DisableSecretDeletion.ValueBool()
 			syncOptionsMap["syncSecretMetadataAsTags"] = syncOptions.SyncSecretMetadataAsTags.ValueBool()
 
 			if syncOptions.KeyID.ValueString() != "" {
@@ -136,7 +144,13 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 				initialSyncBehavior = ""
 			}
 
+			disableSecretDeletion, ok := secretSync.SyncOptions["disableSecretDeletion"].(bool)
+			if !ok {
+				disableSecretDeletion = false
+			}
+
 			syncOptionsMap["initial_sync_behavior"] = types.StringValue(initialSyncBehavior)
+			syncOptionsMap["disable_secret_deletion"] = types.BoolValue(disableSecretDeletion)
 
 			if secretSync.SyncOptions["keyId"] != nil {
 
@@ -228,6 +242,7 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 
 			return types.ObjectValue(map[string]attr.Type{
 				"initial_sync_behavior":        types.StringType,
+				"disable_secret_deletion":      types.BoolType,
 				"aws_kms_key_id":               types.StringType,
 				"sync_secret_metadata_as_tags": types.BoolType,
 				"tags": types.SetType{
@@ -251,6 +266,7 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 			}
 
 			syncOptionsMap["initialSyncBehavior"] = syncOptions.InitialSyncBehavior.ValueString()
+			syncOptionsMap["disableSecretDeletion"] = syncOptions.DisableSecretDeletion.ValueBool()
 			syncOptionsMap["syncSecretMetadataAsTags"] = syncOptions.SyncSecretMetadataAsTags.ValueBool()
 
 			if syncOptions.KeyID.ValueString() != "" {

--- a/internal/provider/resource/secret_sync/secret_sync_azure_key_vault.go
+++ b/internal/provider/resource/secret_sync/secret_sync_azure_key_vault.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -19,7 +20,8 @@ type SecretSyncAzureKeyVaultDestinationConfigModel struct {
 }
 
 type SecretSyncAzureKeyVaultSyncOptionsModel struct {
-	InitialSyncBehavior types.String `tfsdk:"initial_sync_behavior"`
+	InitialSyncBehavior   types.String `tfsdk:"initial_sync_behavior"`
+	DisableSecretDeletion types.Bool   `tfsdk:"disable_secret_deletion"`
 }
 
 func NewSecretSyncAzureKeyVaultResource() resource.Resource {
@@ -39,6 +41,12 @@ func NewSecretSyncAzureKeyVaultResource() resource.Resource {
 				Required:    true,
 				Description: "Specify how Infisical should resolve the initial sync to the destination. Supported options: overwrite-destination, import-prioritize-source, import-prioritize-destination",
 			},
+			"disable_secret_deletion": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When set to true, Infisical will not remove secrets from Azure Key Vault. Enable this option if you intend to manage some secrets manually outside of Infisical.",
+				Default:     booldefault.StaticBool(false),
+			},
 		},
 
 		ReadSyncOptionsForCreateFromPlan: func(ctx context.Context, plan SecretSyncBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
@@ -51,7 +59,7 @@ func NewSecretSyncAzureKeyVaultResource() resource.Resource {
 			}
 
 			syncOptionsMap["initialSyncBehavior"] = syncOptions.InitialSyncBehavior.ValueString()
-
+			syncOptionsMap["disableSecretDeletion"] = syncOptions.DisableSecretDeletion.ValueBool()
 			return syncOptionsMap, nil
 
 		},
@@ -66,6 +74,7 @@ func NewSecretSyncAzureKeyVaultResource() resource.Resource {
 			}
 
 			syncOptionsMap["initialSyncBehavior"] = syncOptions.InitialSyncBehavior.ValueString()
+			syncOptionsMap["disableSecretDeletion"] = syncOptions.DisableSecretDeletion.ValueBool()
 			return syncOptionsMap, nil
 		},
 
@@ -76,12 +85,19 @@ func NewSecretSyncAzureKeyVaultResource() resource.Resource {
 				initialSyncBehavior = ""
 			}
 
+			disableSecretDeletion, ok := secretSync.SyncOptions["disableSecretDeletion"].(bool)
+			if !ok {
+				disableSecretDeletion = false
+			}
+
 			syncOptionsMap := map[string]attr.Value{
-				"initial_sync_behavior": types.StringValue(initialSyncBehavior),
+				"initial_sync_behavior":   types.StringValue(initialSyncBehavior),
+				"disable_secret_deletion": types.BoolValue(disableSecretDeletion),
 			}
 
 			return types.ObjectValue(map[string]attr.Type{
-				"initial_sync_behavior": types.StringType,
+				"initial_sync_behavior":   types.StringType,
+				"disable_secret_deletion": types.BoolType,
 			}, syncOptionsMap)
 		},
 


### PR DESCRIPTION
This PR adds disable secret deletion support for all currently supported secret syncs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional setting to disable secret deletion during sync for AWS Parameter Store, AWS Secrets Manager, Azure App Configuration, Azure Key Vault, and GCP Secret Manager integrations. This allows users to prevent automatic removal of secrets, enabling manual management of certain secrets outside Infisical.

- **Documentation**
  - Updated resource documentation to describe the new option for disabling secret deletion across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->