### PR TITLE
misc: made project user invite idempotent

### DIFF
--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -252,17 +252,29 @@ func (r *ProjectUserResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	var membershipId string
 	if len(invitedUser) == 0 {
-		resp.Diagnostics.AddError(
-			"Error inviting user",
-			"Could not add user to project. No invite was sent, is the user already in the project?",
-		)
-		return
+		projectMember, err := r.client.GetProjectUserByUsername(infisical.GetProjectUserByUserNameRequest{
+			ProjectID: plan.ProjectID.ValueString(),
+			Username:  plan.Username.ValueString(),
+		})
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error inviting user",
+				"User is already in the project but cannot be queried, unexpected error: "+err.Error(),
+			)
+			return
+		}
+
+		membershipId = projectMember.Membership.ID
+	} else {
+		membershipId = invitedUser[0].ID
 	}
 
 	_, err = r.client.UpdateProjectUser(infisical.UpdateProjectUserRequest{
 		ProjectID:    plan.ProjectID.ValueString(),
-		MembershipID: invitedUser[0].ID,
+		MembershipID: membershipId,
 		Roles:        roles,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR updates project user creation flow so that it fetches project membership if user is already invited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling for adding existing users to a project by allowing role updates even if the user is already a member, instead of returning an error.
	- Ensured that membership roles can be updated for users who are already part of the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->