### PR TITLE
feat: corrected issue of secret change policy approvers not working

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1763,7 +1763,7 @@ type SecretApprovalPolicy struct {
 type CreateSecretApprovalPolicyApprover struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
-	Name string `json:"name"`
+	Name string `json:"username"`
 }
 
 type CreateSecretApprovalPolicyRequest struct {
@@ -1792,7 +1792,7 @@ type GetSecretApprovalPolicyByIDResponse struct {
 type UpdateSecretApprovalPolicyApprover struct {
 	Type string `json:"type"`
 	ID   string `json:"id"`
-	Name string `json:"name"`
+	Name string `json:"username"`
 }
 
 type UpdateSecretApprovalPolicyRequest struct {


### PR DESCRIPTION
Users reported secret change approval policy user changes are not getting updated. 

I was able to reproduce this and it seems this was broken long time back. The Go JSON key type is called name where as API expected it to be `username`