### PR TITLE
fix(resource/secret-approval-policy): fix for refresh state

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1790,7 +1790,7 @@ type SecretApprovalPolicyEnvironment struct {
 
 type SecretApprovalPolicyApprover struct {
 	ID   string `json:"id"`
-	Name string `json:"name"`
+	Name string `json:"username"`
 	Type string `json:"type"`
 }
 


### PR DESCRIPTION
Refreshing state (read) was failing because we recently renamed a field on the API from user -> username. This change wasn't reflected in Terraform, meaning the secret-apporval-policy resource would always fail on read.