### PR TITLE
fix: read fails for crossplane

### DIFF
--- a/crossplane/project_role_resource/project_role_resource.go
+++ b/crossplane/project_role_resource/project_role_resource.go
@@ -267,15 +267,13 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	// Permissions V2
-
 	project, err := r.client.GetProject(infisical.GetProjectRequest{
 		Slug: state.ProjectSlug.ValueString(),
 	})
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading project role",
+			"Error reading project",
 			"Unexpected error: "+err.Error(),
 		)
 		return
@@ -287,6 +285,10 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 	})
 
 	if err != nil {
+		if err == infisical.ErrNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error reading project role",
 			"Couldn't read project role from Infisical, unexpected error: "+err.Error(),
@@ -334,7 +336,7 @@ func (r *projectRoleResource) Read(ctx context.Context, req resource.ReadRequest
 
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error reading project role",
+			"Error parsing permissions",
 			"Couldn't parse permissions property, unexpected error: "+err.Error(),
 		)
 		return

--- a/internal/client/project_role.go
+++ b/internal/client/project_role.go
@@ -2,6 +2,7 @@ package infisicalclient
 
 import (
 	"fmt"
+	"net/http"
 	"terraform-provider-infisical/internal/errors"
 )
 
@@ -149,6 +150,9 @@ func (client Client) GetProjectRoleBySlugV2(request GetProjectRoleBySlugV2Reques
 	}
 
 	if response.IsError() {
+		if response.StatusCode() == http.StatusNotFound {
+			return GetProjectRoleBySlugV2Response{}, ErrNotFound
+		}
 		return GetProjectRoleBySlugV2Response{}, errors.NewAPIErrorWithResponse(operationGetProjectRoleBySlugV2, response, nil)
 	}
 


### PR DESCRIPTION
We can't throw errors in Crossplane when resources aren't found. We need to remove it from state and return gracefully, otherwise crossplane gets stuck in a loop trying to read the resource