### PR TITLE
Add warning for duplicated secret sync destination

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2155,6 +2155,17 @@ type DeleteSecretSyncResponse struct {
 	SecretSync SecretSync `json:"secretSync"`
 }
 
+type CheckDuplicateDestinationRequest struct {
+	App               SecretSyncApp
+	DestinationConfig map[string]interface{} `json:"destinationConfig"`
+	ExcludeSyncId     string                 `json:"excludeSyncId,omitempty"`
+	ProjectID         string                 `json:"projectId"`
+}
+
+type CheckDuplicateDestinationResponse struct {
+	HasDuplicate bool `json:"hasDuplicate"`
+}
+
 type DynamicSecret struct {
 	Id               string                 `json:"id"`
 	Name             string                 `json:"name"`

--- a/internal/client/secret_sync.go
+++ b/internal/client/secret_sync.go
@@ -36,10 +36,11 @@ const (
 )
 
 const (
-	operationCreateSecretSync  = "CallCreateSecretSync"
-	operationUpdateSecretSync  = "CallUpdateSecretSync"
-	operationGetSecretSyncById = "CallGetSecretSyncById"
-	operationDeleteSecretSync  = "CallDeleteSecretSync"
+	operationCreateSecretSync          = "CallCreateSecretSync"
+	operationUpdateSecretSync          = "CallUpdateSecretSync"
+	operationGetSecretSyncById         = "CallGetSecretSyncById"
+	operationDeleteSecretSync          = "CallDeleteSecretSync"
+	operationCheckDuplicateDestination = "CallCheckDuplicateDestination"
 )
 
 func (client Client) CreateSecretSync(request CreateSecretSyncRequest) (SecretSync, error) {
@@ -122,4 +123,24 @@ func (client Client) DeleteSecretSync(request DeleteSecretSyncRequest) (SecretSy
 	}
 
 	return body.SecretSync, nil
+}
+
+func (client Client) CheckDuplicateDestination(request CheckDuplicateDestinationRequest) (CheckDuplicateDestinationResponse, error) {
+	var body CheckDuplicateDestinationResponse
+	response, err := client.Config.HttpClient.
+		R().
+		SetResult(&body).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Post(fmt.Sprintf("api/v1/secret-syncs/%s/check-destination", string(request.App)))
+
+	if err != nil {
+		return CheckDuplicateDestinationResponse{}, errors.NewGenericRequestError(operationCheckDuplicateDestination, err)
+	}
+
+	if response.IsError() {
+		return CheckDuplicateDestinationResponse{}, errors.NewAPIErrorWithResponse(operationCheckDuplicateDestination, response, nil)
+	}
+
+	return body, nil
 }


### PR DESCRIPTION
Add a warning when a new secret sync with a duplicated destination configuration is set (could be risky if done without proper managment)

<img width="2212" height="292" alt="CleanShot 2025-09-29 at 22 25 56@2x" src="https://github.com/user-attachments/assets/38b1108a-dbdc-4fad-aa44-e83e6b6c4d30" />
