### PR TITLE
fix: uses id in project creation and creation

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -635,7 +635,8 @@ type GetProjectByIdRequest struct {
 }
 
 type UpdateProjectRequest struct {
-	Slug                string `json:"slug"`
+	ProjectId           string `json:"projectId"`
+	ProjectSlug         string `json:"slug"`
 	ProjectName         string `json:"name"`
 	ProjectDescription  string `json:"description"`
 	HasDeleteProtection bool   `json:"hasDeleteProtection"`

--- a/internal/client/project.go
+++ b/internal/client/project.go
@@ -92,7 +92,7 @@ func (client Client) UpdateProject(request UpdateProjectRequest) (UpdateProjectR
 		SetResult(&projectResponse).
 		SetHeader("User-Agent", USER_AGENT).
 		SetBody(request).
-		Patch(fmt.Sprintf("api/v2/workspace/%s", request.Slug))
+		Patch(fmt.Sprintf("api/v1/projects/%s", request.ProjectId))
 
 	if err != nil {
 		return UpdateProjectResponse{}, errors.NewGenericRequestError(operationUpdateProject, err)


### PR DESCRIPTION
Depends on: https://github.com/Infisical/infisical/pull/4745

Fix: Updates the project resource to use an id instead of a slug. This helps us check for updates and duplication.

## Changes: 
| No. | Condition | Before | After |
|--------|--------|--------|--------|
|1 | Changing slug | create a new resource | detects the change and updates the existing resource |
|2 | Creating a new project with the slug of an existing project | 500 error | 400 error with reason |
| 3 | Updating a project to use the slug of another existing project | 400 error | 400 error with reason |

## Tests to Verify the Changes:

- Test 1:  Creating a new project should work fine.

- Test 2: Update a Project
  - Create a project using Terraform (TF).
  - Update the project from the UI.
  - Run terraform apply again — it should detect the changes and successfully update the existing project.

- Test 3: Create a Project with an Existing Slug
  - create a new project with a slug that already exists: should return a 400 error with the reason.

- Test 4: Update a Project to Use an Existing Slug
  - update an existing project to use the slug of another existing project: should return a 400 error with the reason.