### PR TITLE
fix: used new project ID in get after create

### DIFF
--- a/internal/provider/resource/project_resource.go
+++ b/internal/provider/resource/project_resource.go
@@ -212,7 +212,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	project, err := r.client.GetProjectById(infisical.GetProjectByIdRequest{
-		ID: plan.ID.ValueString(),
+		ID: newProject.Project.ID,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR uses new project ID after create for the getProjectById operation instead of the one in the plan (which is undefined)