### PR TITLE
fix: address blank ID issue for secret resource

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -553,6 +553,10 @@ type GetRawSecretsV3Request struct {
 	ExpandSecretReferences bool   `json:"expandSecretReferences"`
 }
 
+type CreateRawSecretsV3Response struct {
+	Secret RawV3Secret `json:"secret"`
+}
+
 type RawV3Secret struct {
 	ID            string `json:"id"`
 	Version       int    `json:"version"`

--- a/internal/client/secrets.go
+++ b/internal/client/secrets.go
@@ -197,7 +197,7 @@ func (client Client) GetSecretsRawV3(request GetRawSecretsV3Request) (GetRawSecr
 }
 
 func (client Client) CreateRawSecretsV3(request CreateRawSecretV3Request) (RawV3Secret, error) {
-	var secretsResponse RawV3Secret
+	var secretsResponse CreateRawSecretsV3Response
 	response, err := client.Config.HttpClient.
 		R().
 		SetResult(&secretsResponse).
@@ -214,7 +214,7 @@ func (client Client) CreateRawSecretsV3(request CreateRawSecretV3Request) (RawV3
 		return RawV3Secret{}, errors.NewAPIErrorWithResponse(operationCreateRawSecretsV3, response, &additionalContext)
 	}
 
-	return secretsResponse, nil
+	return secretsResponse.Secret, nil
 }
 
 func (client Client) DeleteRawSecretV3(request DeleteRawSecretV3Request) error {


### PR DESCRIPTION
This PR addresses the issue where secret ID value in the state is empty after resource creation