### PR TITLE
feature(secrets): add metadata support for secret resources

### DIFF
--- a/docs/ephemeral-resources/secret.md
+++ b/docs/ephemeral-resources/secret.md
@@ -77,4 +77,5 @@ provider "postgresql" {
 
 ### Read-Only
 
+- `metadata` (Map of String) Metadata associated with the secret as key-value pairs.
 - `value` (String, Sensitive) The value of the secret

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -90,6 +90,7 @@ ephemeral "infisical_secret" "ephemeral-secret" {
 
 ### Optional
 
+- `metadata` (Map of String) Metadata associated with the secret as key-value pairs.
 - `secret_reminder` (Attributes) (see [below for nested schema](#nestedatt--secret_reminder))
 - `tag_ids` (List of String) Tag ids to be attached for the secrets.
 - `value` (String, Sensitive) The value of the secret in plain text. This is required if `value_wo` is not set.

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -557,6 +557,11 @@ type CreateRawSecretsV3Response struct {
 	Secret RawV3Secret `json:"secret"`
 }
 
+type SecretMetadataItem struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 type RawV3Secret struct {
 	ID            string `json:"id"`
 	Version       int    `json:"version"`
@@ -568,8 +573,9 @@ type RawV3Secret struct {
 	SecretValue   string `json:"secretValue"`
 	SecretComment string `json:"secretComment"`
 
-	SecretReminderNote       string `json:"secretReminderNote"`
-	SecretReminderRepeatDays int64  `json:"secretReminderRepeatDays"`
+	SecretReminderNote       string               `json:"secretReminderNote"`
+	SecretReminderRepeatDays int64                `json:"secretReminderRepeatDays"`
+	SecretMetadata           []SecretMetadataItem `json:"secretMetadata"`
 	Tags                     []struct {
 		ID    string `json:"id"`
 		Slug  string `json:"slug"`
@@ -598,8 +604,9 @@ type GetSingleSecretByIDV3Response = struct {
 		SecretComment string `json:"secretComment"`
 		SecretPath    string `json:"secretPath"`
 
-		SecretReminderNote       string `json:"secretReminderNote"`
-		SecretReminderRepeatDays int64  `json:"secretReminderRepeatDays"`
+		SecretReminderNote       string               `json:"secretReminderNote"`
+		SecretReminderRepeatDays int64                `json:"secretReminderRepeatDays"`
+		SecretMetadata           []SecretMetadataItem `json:"secretMetadata"`
 		Tags                     []struct {
 			ID    string `json:"id"`
 			Slug  string `json:"slug"`
@@ -611,16 +618,17 @@ type GetSingleSecretByIDV3Response = struct {
 
 // create secrets.
 type CreateRawSecretV3Request struct {
-	WorkspaceID              string   `json:"workspaceId"`
-	Type                     string   `json:"type"`
-	Environment              string   `json:"environment"`
-	SecretKey                string   `json:"secretKey"`
-	SecretValue              string   `json:"secretValue"`
-	SecretComment            string   `json:"secretComment"`
-	SecretPath               string   `json:"secretPath"`
-	SecretReminderNote       string   `json:"secretReminderNote"`
-	SecretReminderRepeatDays int64    `json:"secretReminderRepeatDays"`
-	TagIDs                   []string `json:"tagIds"`
+	WorkspaceID              string               `json:"workspaceId"`
+	Type                     string               `json:"type"`
+	Environment              string               `json:"environment"`
+	SecretKey                string               `json:"secretKey"`
+	SecretValue              string               `json:"secretValue"`
+	SecretComment            string               `json:"secretComment"`
+	SecretPath               string               `json:"secretPath"`
+	SecretReminderNote       string               `json:"secretReminderNote"`
+	SecretReminderRepeatDays int64                `json:"secretReminderRepeatDays"`
+	SecretMetadata           []SecretMetadataItem `json:"secretMetadata,omitempty"`
+	TagIDs                   []string             `json:"tagIds"`
 }
 
 type DeleteRawSecretV3Request struct {
@@ -633,15 +641,16 @@ type DeleteRawSecretV3Request struct {
 
 // update secret by name api.
 type UpdateRawSecretByNameV3Request struct {
-	SecretName               string   `json:"secretName"`
-	WorkspaceID              string   `json:"workspaceId"`
-	Environment              string   `json:"environment"`
-	Type                     string   `json:"type"`
-	SecretPath               string   `json:"secretPath"`
-	SecretReminderNote       string   `json:"secretReminderNote"`
-	SecretReminderRepeatDays int64    `json:"secretReminderRepeatDays"`
-	SecretValue              *string  `json:"secretValue,omitempty"`
-	TagIDs                   []string `json:"tagIds"`
+	SecretName               string               `json:"secretName"`
+	WorkspaceID              string               `json:"workspaceId"`
+	Environment              string               `json:"environment"`
+	Type                     string               `json:"type"`
+	SecretPath               string               `json:"secretPath"`
+	SecretReminderNote       string               `json:"secretReminderNote"`
+	SecretReminderRepeatDays int64                `json:"secretReminderRepeatDays"`
+	SecretValue              *string              `json:"secretValue,omitempty"`
+	SecretMetadata           []SecretMetadataItem `json:"secretMetadata,omitempty"`
+	TagIDs                   []string             `json:"tagIds"`
 }
 
 type CreateProjectRequest struct {


### PR DESCRIPTION
This PR adds metadata support for secrets and the ephemeral secrets resource.

You can create, update, and get the metadata field.

Tests:

- [ ] Create a secret WITH metadata
- [ ] Create a secret WITHOUT metadata
- [ ] Update a secret with metadata
- [ ] Read metadata from ephemeral secret with metadata
- [ ] Try to read metadata from ephemeral secret without metadata