### PR TITLE
improvement(secret-sync): add warnings for overwrite destination in secret sync resources

### DIFF
--- a/internal/provider/resource/secret_sync/base_secret_sync.go
+++ b/internal/provider/resource/secret_sync/base_secret_sync.go
@@ -20,6 +20,7 @@ type SecretSyncBaseResource struct {
 	ResourceTypeName                       string                  // terraform resource name suffix
 	SyncName                               string                  // complete descriptive name of the secret sync
 	AppConnection                          infisical.AppConnectionApp
+	CanImportSecrets                       bool // whether this sync destination supports importing secrets from the destination
 	client                                 *infisical.Client
 	DestinationConfigAttributes            map[string]schema.Attribute
 	ReadDestinationConfigForCreateFromPlan func(ctx context.Context, plan SecretSyncBaseResourceModel) (map[string]interface{}, diag.Diagnostics)
@@ -134,6 +135,8 @@ func (r *SecretSyncBaseResource) ModifyPlan(ctx context.Context, req resource.Mo
 		return
 	}
 
+	r.addOverwriteDestinationWarnings(ctx, plan, resp)
+
 	if !req.State.Raw.IsNull() {
 		var state SecretSyncBaseResourceModel
 		if diags := req.State.Get(ctx, &state); !diags.HasError() {
@@ -181,6 +184,34 @@ func (r *SecretSyncBaseResource) ModifyPlan(ctx context.Context, req resource.Mo
 		resp.Diagnostics.AddWarning(
 			"Duplicate destination configuration detected",
 			"A secret sync with the same destination configuration already exists in this project. Proceeding with this operation may result in conflicts or unexpected behavior.",
+		)
+	}
+}
+
+// addOverwriteDestinationWarnings adds warnings when using overwrite destination initial sync behavior.
+func (r *SecretSyncBaseResource) addOverwriteDestinationWarnings(ctx context.Context, plan SecretSyncBaseResourceModel, resp *resource.ModifyPlanResponse) {
+	syncOptions, diags := r.ReadSyncOptionsForCreateFromPlan(ctx, plan)
+	if diags.HasError() {
+		return
+	}
+
+	initialSyncBehavior, _ := syncOptions["initialSyncBehavior"].(string)
+	disableSecretDeletion, _ := syncOptions["disableSecretDeletion"].(bool)
+
+	if disableSecretDeletion {
+		return
+	}
+
+	if !r.CanImportSecrets {
+		resp.Diagnostics.AddWarning(
+			fmt.Sprintf("%s only supports overwriting destination secrets", r.SyncName),
+			fmt.Sprintf("Secrets not present in Infisical will be removed from the destination. Consider adding a key_schema or setting disable_secret_deletion to true if you do not want existing secrets to be removed from %s.", r.SyncName),
+		)
+	} else if initialSyncBehavior == string(infisical.SecretSyncBehaviorOverwriteDestination) {
+		// Destination supports import but user chose overwrite - warn about secret deletion with import suggestion
+		resp.Diagnostics.AddWarning(
+			"Overwrite destination will remove secrets not present in Infisical",
+			fmt.Sprintf("Secrets not present in Infisical will be removed from the destination. If you have secrets in %s that you do not want deleted, consider setting initial_sync_behavior to import-prioritize-source or import-prioritize-destination. Alternatively, configure a key_schema or set disable_secret_deletion to true to have Infisical ignore these secrets.", r.SyncName),
 		)
 	}
 }

--- a/internal/provider/resource/secret_sync/secret_sync_1password.go
+++ b/internal/provider/resource/secret_sync/secret_sync_1password.go
@@ -31,6 +31,7 @@ func NewSecretSync1PasswordResource() resource.Resource {
 		SyncName:         "1Password",
 		ResourceTypeName: "_secret_sync_1password",
 		AppConnection:    infisical.AppConnectionApp1Password,
+		CanImportSecrets: true,
 		DestinationConfigAttributes: map[string]schema.Attribute{
 			"vault_id": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_aws_parameter_store.go
+++ b/internal/provider/resource/secret_sync/secret_sync_aws_parameter_store.go
@@ -39,6 +39,7 @@ func NewSecretSyncAwsParameterStoreResource() resource.Resource {
 		SyncName:         "AWS Parameter Store",
 		ResourceTypeName: "_secret_sync_aws_parameter_store",
 		AppConnection:    infisical.AppConnectionAppAWS,
+		CanImportSecrets: true,
 		DestinationConfigAttributes: map[string]schema.Attribute{
 			"aws_region": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_aws_secrets_manager.go
+++ b/internal/provider/resource/secret_sync/secret_sync_aws_secrets_manager.go
@@ -41,6 +41,7 @@ func NewSecretSyncAwsSecretsManagerResource() resource.Resource {
 		SyncName:         "AWS Secrets Manager",
 		ResourceTypeName: "_secret_sync_aws_secrets_manager",
 		AppConnection:    infisical.AppConnectionAppAWS,
+		CanImportSecrets: true,
 		DestinationConfigAttributes: map[string]schema.Attribute{
 			"aws_region": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_azure_app_configuration.go
+++ b/internal/provider/resource/secret_sync/secret_sync_azure_app_configuration.go
@@ -32,6 +32,7 @@ func NewSecretSyncAzureAppConfigurationResource() resource.Resource {
 		SyncName:         "Azure App Configuration",
 		ResourceTypeName: "_secret_sync_azure_app_configuration",
 		AppConnection:    infisical.AppConnectionAppAzure,
+		CanImportSecrets: true,
 		SyncOptionsAttributes: map[string]schema.Attribute{
 			"initial_sync_behavior": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_azure_key_vault.go
+++ b/internal/provider/resource/secret_sync/secret_sync_azure_key_vault.go
@@ -30,6 +30,7 @@ func NewSecretSyncAzureKeyVaultResource() resource.Resource {
 		SyncName:         "Azure Key Vault",
 		ResourceTypeName: "_secret_sync_azure_key_vault",
 		AppConnection:    infisical.AppConnectionAppAzure,
+		CanImportSecrets: true,
 		DestinationConfigAttributes: map[string]schema.Attribute{
 			"vault_base_url": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_gcp_secret_manager.go
+++ b/internal/provider/resource/secret_sync/secret_sync_gcp_secret_manager.go
@@ -34,6 +34,7 @@ func NewSecretSyncGcpSecretManagerResource() resource.Resource {
 		SyncName:         "GCP Secret Manager",
 		ResourceTypeName: "_secret_sync_gcp_secret_manager",
 		AppConnection:    "GCP",
+		CanImportSecrets: true,
 		SyncOptionsAttributes: map[string]schema.Attribute{
 			"initial_sync_behavior": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource/secret_sync/secret_sync_render.go
+++ b/internal/provider/resource/secret_sync/secret_sync_render.go
@@ -135,6 +135,7 @@ func NewSecretSyncRenderResource() resource.Resource {
 		App:              infisical.SecretSyncAppRender,
 		SyncName:         "Render",
 		ResourceTypeName: "_secret_sync_render",
+		CanImportSecrets: true,
 		AppConnection:    infisical.AppConnectionAppRender,
 		DestinationConfigAttributes: map[string]schema.Attribute{
 			"scope": schema.StringAttribute{


### PR DESCRIPTION
This PR adds warning messages during terraform plan when using secret syncs with overwrite destination behavior, following the same pattern implemented in the UI https://github.com/Infisical/infisical/pull/5015.

<img width="1030" height="142" alt="image" src="https://github.com/user-attachments/assets/1c3b4223-6e87-49ca-ba24-4fa02beef02b" />

<img width="1013" height="166" alt="image" src="https://github.com/user-attachments/assets/8bd0100c-7285-43fc-8668-12d293d9fa1b" />

Testing:

- Test with resources that don't support import (GitHub, for example)
- Test with resources that support import, but using overwrite-destination (AWS Secrets Manager, for example)
- Test with `disable_secret_deletion = true` (no warning should show up)