### PR TITLE
feat: add gateway_id support and Redis app connection

### DIFF
--- a/internal/client/app_connection.go
+++ b/internal/client/app_connection.go
@@ -23,6 +23,7 @@ const (
 	AppConnectionAppMsSql                 AppConnectionApp = "mssql"
 	AppConnectionAppPostgres              AppConnectionApp = "postgres"
 	AppConnectionAppOracle                AppConnectionApp = "oracledb"
+	AppConnectionAppRedis                 AppConnectionApp = "redis"
 	AppConnectionApp1Password             AppConnectionApp = "1password"
 	AppConnectionAppRender                AppConnectionApp = "render"
 	AppConnectionAppAzureClientSecrets    AppConnectionApp = "azure-client-secrets"

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2161,6 +2161,7 @@ type AppConnection struct {
 	App             string  `json:"app"`
 	Method          string  `json:"method"`
 	CredentialsHash string  `json:"credentialsHash"`
+	GatewayId       *string `json:"gatewayId"`
 }
 
 type CreateAppConnectionRequest struct {
@@ -2170,6 +2171,7 @@ type CreateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   string                 `json:"gatewayId,omitempty"`
 }
 
 type CreateAppConnectionResponse struct {
@@ -2193,6 +2195,7 @@ type UpdateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials,omitempty"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   string                 `json:"gatewayId,omitempty"`
 }
 
 type UpdateAppConnectionResponse struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -399,6 +399,7 @@ func (p *infisicalProvider) Resources(_ context.Context) []func() resource.Resou
 		appConnectionResource.NewAppConnectionMySqlResource,
 		appConnectionResource.NewAppConnectionMsSqlResource,
 		appConnectionResource.NewAppConnectionPostgresResource,
+		appConnectionResource.NewAppConnectionRedisResource,
 		appConnectionResource.NewAppConnectionOracleDbResource,
 		appConnectionResource.NewAppConnectionBitbucketResource,
 		appConnectionResource.NewAppConnectionDatabricksResource,

--- a/internal/provider/resource/app_connection/app_connection_redis.go
+++ b/internal/provider/resource/app_connection/app_connection_redis.go
@@ -1,0 +1,232 @@
+package resource
+
+import (
+	"context"
+	infisical "terraform-provider-infisical/internal/client"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// AppConnectionRedisCredentialsModel describes the data source data model.
+type AppConnectionRedisCredentialsModel struct {
+	Host                  types.String `tfsdk:"host"`
+	Port                  types.Int32  `tfsdk:"port"`
+	Database              types.Int32  `tfsdk:"database"`
+	Username              types.String `tfsdk:"username"`
+	Password              types.String `tfsdk:"password"`
+	SslEnabled            types.Bool   `tfsdk:"ssl_enabled"`
+	SslRejectUnauthorized types.Bool   `tfsdk:"ssl_reject_unauthorized"`
+	SslCertificate        types.String `tfsdk:"ssl_certificate"`
+}
+
+const AppConnectionRedisAuthMethodUsernameAndPassword = "username-and-password"
+const AppConnectionRedisAuthMethodPassword = "password"
+
+func NewAppConnectionRedisResource() resource.Resource {
+	return &AppConnectionBaseResource{
+		App:               infisical.AppConnectionAppRedis,
+		AppConnectionName: "Redis",
+		ResourceTypeName:  "_app_connection_redis",
+		AllowedMethods:    []string{AppConnectionRedisAuthMethodUsernameAndPassword, AppConnectionRedisAuthMethodPassword},
+		CredentialsAttributes: map[string]schema.Attribute{
+			"host": schema.StringAttribute{
+				Required:    true,
+				Description: "The hostname of the Redis server.",
+			},
+			"port": schema.Int32Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The port number of the Redis server.",
+				Default:     int32default.StaticInt32(6379),
+			},
+			"database": schema.Int32Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The Redis database number (0-15).",
+				Default:     int32default.StaticInt32(0),
+			},
+			"username": schema.StringAttribute{
+				Optional:    true,
+				Description: "The username for Redis authentication (Redis 6+ ACL).",
+			},
+			"password": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "The password for Redis authentication.",
+			},
+			"ssl_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether or not to use SSL when connecting to Redis.",
+				Default:     booldefault.StaticBool(false),
+			},
+			"ssl_reject_unauthorized": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether or not to reject unauthorized SSL certificates when connecting to Redis.",
+				Default:     booldefault.StaticBool(true),
+			},
+			"ssl_certificate": schema.StringAttribute{
+				Optional:    true,
+				Description: "The SSL certificate to use for connection.",
+			},
+		},
+		ReadCredentialsForCreateFromPlan: func(ctx context.Context, plan AppConnectionBaseResourceModel) (map[string]any, diag.Diagnostics) {
+			credentialsConfig := make(map[string]any)
+
+			var credentials AppConnectionRedisCredentialsModel
+			diags := plan.Credentials.As(ctx, &credentials, basetypes.ObjectAsOptions{})
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			if plan.Method.ValueString() != AppConnectionRedisAuthMethodUsernameAndPassword && plan.Method.ValueString() != AppConnectionRedisAuthMethodPassword {
+				diags.AddError(
+					"Unable to create Redis app connection",
+					"Invalid method. Only username-and-password or password method is supported",
+				)
+				return nil, diags
+			}
+
+			credentialsConfig["host"] = credentials.Host.ValueString()
+			credentialsConfig["port"] = credentials.Port.ValueInt32()
+			credentialsConfig["database"] = credentials.Database.ValueInt32()
+			credentialsConfig["username"] = credentials.Username.ValueString()
+			credentialsConfig["password"] = credentials.Password.ValueString()
+			credentialsConfig["sslEnabled"] = credentials.SslEnabled.ValueBool()
+			credentialsConfig["sslRejectUnauthorized"] = credentials.SslRejectUnauthorized.ValueBool()
+			credentialsConfig["sslCertificate"] = credentials.SslCertificate.ValueString()
+
+			return credentialsConfig, diags
+		},
+		ReadCredentialsForUpdateFromPlan: func(ctx context.Context, plan AppConnectionBaseResourceModel, state AppConnectionBaseResourceModel) (map[string]any, diag.Diagnostics) {
+			credentialsConfig := make(map[string]any)
+
+			var credentialsFromPlan AppConnectionRedisCredentialsModel
+			diags := plan.Credentials.As(ctx, &credentialsFromPlan, basetypes.ObjectAsOptions{})
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			var credentialsFromState AppConnectionRedisCredentialsModel
+			diags = state.Credentials.As(ctx, &credentialsFromState, basetypes.ObjectAsOptions{})
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			if plan.Method.ValueString() != AppConnectionRedisAuthMethodUsernameAndPassword && plan.Method.ValueString() != AppConnectionRedisAuthMethodPassword {
+				diags.AddError(
+					"Unable to update Redis app connection",
+					"Invalid method. Only username-and-password or password method is supported",
+				)
+				return nil, diags
+			}
+
+			host := credentialsFromPlan.Host
+			if credentialsFromPlan.Host.IsUnknown() {
+				host = credentialsFromState.Host
+			}
+			if !host.IsNull() {
+				credentialsConfig["host"] = host.ValueString()
+			}
+
+			port := credentialsFromPlan.Port
+			if credentialsFromPlan.Port.IsUnknown() {
+				port = credentialsFromState.Port
+			}
+			if !port.IsNull() {
+				credentialsConfig["port"] = port.ValueInt32()
+			}
+
+			database := credentialsFromPlan.Database
+			if credentialsFromPlan.Database.IsUnknown() {
+				database = credentialsFromState.Database
+			}
+			if !database.IsNull() {
+				credentialsConfig["database"] = database.ValueInt32()
+			}
+
+			username := credentialsFromPlan.Username
+			if credentialsFromPlan.Username.IsUnknown() {
+				username = credentialsFromState.Username
+			}
+			if !username.IsNull() {
+				credentialsConfig["username"] = username.ValueString()
+			}
+
+			password := credentialsFromPlan.Password
+			if credentialsFromPlan.Password.IsUnknown() {
+				password = credentialsFromState.Password
+			}
+			if !password.IsNull() {
+				credentialsConfig["password"] = password.ValueString()
+			}
+
+			sslEnabled := credentialsFromPlan.SslEnabled
+			if credentialsFromPlan.SslEnabled.IsUnknown() {
+				sslEnabled = credentialsFromState.SslEnabled
+			}
+			if !sslEnabled.IsNull() {
+				credentialsConfig["sslEnabled"] = sslEnabled.ValueBool()
+			}
+
+			sslRejectUnauthorized := credentialsFromPlan.SslRejectUnauthorized
+			if credentialsFromPlan.SslRejectUnauthorized.IsUnknown() {
+				sslRejectUnauthorized = credentialsFromState.SslRejectUnauthorized
+			}
+			if !sslRejectUnauthorized.IsNull() {
+				credentialsConfig["sslRejectUnauthorized"] = sslRejectUnauthorized.ValueBool()
+			}
+
+			sslCertificate := credentialsFromPlan.SslCertificate
+			if credentialsFromPlan.SslCertificate.IsUnknown() {
+				sslCertificate = credentialsFromState.SslCertificate
+			}
+			if !sslCertificate.IsNull() {
+				credentialsConfig["sslCertificate"] = sslCertificate.ValueString()
+			}
+
+			return credentialsConfig, diags
+		},
+		OverwriteCredentialsFields: func(state *AppConnectionBaseResourceModel) diag.Diagnostics {
+			credentialsConfig := map[string]attr.Value{
+				"host":                    types.StringNull(),
+				"port":                    types.Int32Null(),
+				"database":                types.Int32Null(),
+				"username":                types.StringNull(),
+				"password":                types.StringNull(),
+				"ssl_enabled":             types.BoolNull(),
+				"ssl_reject_unauthorized": types.BoolNull(),
+				"ssl_certificate":         types.StringNull(),
+			}
+
+			credentialsObj, diags := types.ObjectValue(
+				map[string]attr.Type{
+					"host":                    types.StringType,
+					"port":                    types.Int32Type,
+					"database":                types.Int32Type,
+					"username":                types.StringType,
+					"password":                types.StringType,
+					"ssl_enabled":             types.BoolType,
+					"ssl_reject_unauthorized": types.BoolType,
+					"ssl_certificate":         types.StringType,
+				},
+				credentialsConfig,
+			)
+
+			if diags.HasError() {
+				return diags
+			}
+
+			state.Credentials = credentialsObj
+			return nil
+		},
+	}
+}

--- a/internal/provider/resource/app_connection/base_app_connection.go
+++ b/internal/provider/resource/app_connection/base_app_connection.go
@@ -35,6 +35,7 @@ type AppConnectionBaseResourceModel struct {
 	ProjectId       types.String `tfsdk:"project_id"`
 	Credentials     types.Object `tfsdk:"credentials"`
 	CredentialsHash types.String `tfsdk:"credentials_hash"`
+	GatewayId       types.String `tfsdk:"gateway_id"`
 }
 
 // Metadata returns the resource type name.
@@ -76,6 +77,10 @@ func (r *AppConnectionBaseResource) Schema(_ context.Context, _ resource.SchemaR
 			"credentials_hash": schema.StringAttribute{
 				Computed:    true,
 				Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
+			},
+			"gateway_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The ID of the gateway to use for this connection.",
 			},
 		},
 	}
@@ -148,6 +153,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 		Method:      plan.Method.ValueString(),
 		Credentials: credentialsMap,
 		ProjectId:   plan.ProjectId.ValueString(),
+		GatewayId:   plan.GatewayId.ValueString(),
 	})
 
 	if err != nil {
@@ -232,6 +238,12 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 		state.ProjectId = types.StringNull()
 	}
 
+	if appConnection.GatewayId != nil {
+		state.GatewayId = types.StringValue(*appConnection.GatewayId)
+	} else {
+		state.GatewayId = types.StringNull()
+	}
+
 	state.Method = types.StringValue(appConnection.Method)
 	state.Name = types.StringValue(appConnection.Name)
 
@@ -293,6 +305,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 		Method:      plan.Method.ValueString(),
 		Credentials: credentialsMap,
 		ProjectId:   plan.ProjectId.ValueString(),
+		GatewayId:   plan.GatewayId.ValueString(),
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR adds two major features to the Infisical Terraform provider:

1. **gateway_id support for all app connections** - Allows specifying a gateway to connect to internal resources via the Infisical Gateway/Relay infrastructure
2. **Redis app connection resource** - New \infisical_app_connection_redis\ resource type

## Changes

### Commit 1: gateway_id support
- Added GatewayId field to CreateAppConnectionRequest, UpdateAppConnectionRequest, and AppConnection structs
- Added gateway_id schema attribute to base app connection resource (optional)
- Implemented Create/Read/Update support for gateway_id in base resource

### Commit 2: Redis app connection
- Created new app_connection_redis.go resource file (~230 lines)
- Added Redis credentials model with: host, port, database, username, password, SSL options
- Implemented full CRUD operations following existing patterns
- Registered Redis resource in provider
- Supports username-and-password authentication method

## Usage Example

### PostgreSQL with Gateway

codeblock hcl
resource "infisical_app_connection_postgres" "postgres_kb" {
  name        = "postgres-kb"
  method      = "username-and-password"
  project_id  = var.project_id
  gateway_id  = "73bde130-fdd5-4e19-8f99-d94da2bd7cf6"
  
  credentials = {
    host     = "postgres-kb-postgresql.postgres.svc.cluster.local"
    port     = 5432
    database = "postgres"
    username = "postgres"
    password = var.password
  }
}

### Redis App Connection

codeblock hcl
resource "infisical_app_connection_redis" "redis_kb" {
  name        = "redis-kb"
  method      = "username-and-password"
  project_id  = var.project_id
  
  credentials = {
    host     = "redis-kb-redis.redis.svc.cluster.local"
    port     = 6379
    database = 0
    username = "default"
    password = var.password
  }
}

## Testing
- [x] Terraform plan validation passes
- [x] Schema generates correctly for both resources
- [x] Gateway ID properly passed in API requests
- [ ] Redis backend support may need verification on Infisical Cloud side

## Notes
- Gateway feature requires Infisical paid plan
- Changes are backwards compatible - gateway_id is optional
- Follows existing code patterns from other app connections (postgres, mysql, etc.)

---

This implementation enables infrastructure-as-code for app connections that need to access private/internal resources via the Infisical Gateway.