### PR TITLE
improvement(secret-ephemeral): return version of the secret 

### DIFF
--- a/docs/ephemeral-resources/secret.md
+++ b/docs/ephemeral-resources/secret.md
@@ -52,8 +52,10 @@ ephemeral "infisical_secret" "postgres_password" {
 
 locals {
   credentials = {
-    username = ephemeral.infisical_secret.postgres_username.value
-    password = ephemeral.infisical_secret.postgres_password.value
+    username         = ephemeral.infisical_secret.postgres_username.value
+    username_version = ephemeral.infisical_secret.postgres_username.version
+    password         = ephemeral.infisical_secret.postgres_password.value
+    password_version = ephemeral.infisical_secret.postgres_password.version
   }
 }
 

--- a/docs/ephemeral-resources/secret.md
+++ b/docs/ephemeral-resources/secret.md
@@ -52,10 +52,8 @@ ephemeral "infisical_secret" "postgres_password" {
 
 locals {
   credentials = {
-    username         = ephemeral.infisical_secret.postgres_username.value
-    username_version = ephemeral.infisical_secret.postgres_username.version
-    password         = ephemeral.infisical_secret.postgres_password.value
-    password_version = ephemeral.infisical_secret.postgres_password.version
+    username = ephemeral.infisical_secret.postgres_username.value
+    password = ephemeral.infisical_secret.postgres_password.value
   }
 }
 

--- a/docs/ephemeral-resources/secret.md
+++ b/docs/ephemeral-resources/secret.md
@@ -79,3 +79,4 @@ provider "postgresql" {
 
 - `metadata` (Map of String) Metadata associated with the secret as key-value pairs.
 - `value` (String, Sensitive) The value of the secret
+- `version` (Number) The version number of the secret

--- a/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
@@ -37,10 +37,8 @@ ephemeral "infisical_secret" "postgres_password" {
 
 locals {
   credentials = {
-    username         = ephemeral.infisical_secret.postgres_username.value
-    username_version = ephemeral.infisical_secret.postgres_username.version
-    password         = ephemeral.infisical_secret.postgres_password.value
-    password_version = ephemeral.infisical_secret.postgres_password.version
+    username = ephemeral.infisical_secret.postgres_username.value
+    password = ephemeral.infisical_secret.postgres_password.value
   }
 }
 

--- a/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/infisical_secret/ephemeral-resource.tf
@@ -37,8 +37,10 @@ ephemeral "infisical_secret" "postgres_password" {
 
 locals {
   credentials = {
-    username = ephemeral.infisical_secret.postgres_username.value
-    password = ephemeral.infisical_secret.postgres_password.value
+    username         = ephemeral.infisical_secret.postgres_username.value
+    username_version = ephemeral.infisical_secret.postgres_username.version
+    password         = ephemeral.infisical_secret.postgres_password.value
+    password_version = ephemeral.infisical_secret.postgres_password.version
   }
 }
 

--- a/internal/provider/resource/secret_resource_ephemeral.go
+++ b/internal/provider/resource/secret_resource_ephemeral.go
@@ -32,6 +32,7 @@ type ephemeralSecretResourceModel struct {
 	Value       types.String `tfsdk:"value"`
 	WorkspaceId types.String `tfsdk:"workspace_id"`
 	Metadata    types.Map    `tfsdk:"metadata"`
+	Version     types.Int64  `tfsdk:"version"`
 }
 
 // Metadata returns the resource type name.
@@ -72,6 +73,10 @@ func (r *ephemeralSecretResource) Schema(_ context.Context, _ ephemeral.SchemaRe
 			"metadata": schema.MapAttribute{
 				ElementType: types.StringType,
 				Description: "Metadata associated with the secret as key-value pairs.",
+				Computed:    true,
+			},
+			"version": schema.Int64Attribute{
+				Description: "The version number of the secret",
 				Computed:    true,
 			},
 		},
@@ -160,5 +165,6 @@ func (r *ephemeralSecretResource) Open(ctx context.Context, req ephemeral.OpenRe
 		EnvSlug:     config.EnvSlug,
 		WorkspaceId: config.WorkspaceId,
 		Metadata:    metadata,
+		Version:     types.Int64Value(int64(res.Secret.Version)),
 	})
 }


### PR DESCRIPTION
Did some test with tf.debug: 

```
2026-04-07T17:36:21.860-0300 [DEBUG] provider.terraform-provider-infisical: Secret: 2232: @caller=/Users/adilsitos/Documents/infisical/terraform-provider-infisical/internal/provider/resource/secret_resource_ephemeral.go:138 @module=infisical secret_key=POSTGRES_PASSWORD secret_metadata=[] tf_ephemeral_resource_type=infisical_secret tf_provider_addr=registry.terraform.io/infisical/infisical secret_value=2232 secret_version=2 tf_req_id=1ab5a833-6ecf-16b0-ddb9-01955ecdebce tf_rpc=OpenEphemeralResource timestamp=2026-04-07T17:36:21.860-0300
```

Secret version is being returned. 