### PR TITLE
fix(secret-approval): add unorderedListModifier

### DIFF
--- a/internal/provider/resource/secret_approval_policy.go
+++ b/internal/provider/resource/secret_approval_policy.go
@@ -207,14 +207,11 @@ func (r *secretApprovalPolicyResource) Create(ctx context.Context, req resource.
 	}
 
 	var environments []string
+	var environment string
 	if !plan.EnvironmentSlugs.IsNull() {
 		environments = infisicaltf.StringListToGoStringSlice(ctx, resp.Diagnostics, plan.EnvironmentSlugs)
 	} else {
-		environments = []string{plan.EnvironmentSlug.ValueString()}
-	}
-	var environment string
-	if len(environments) > 0 {
-		environment = environments[0]
+		environment = plan.EnvironmentSlug.ValueString()
 	}
 
 	secretApprovalPolicy, err := r.client.CreateSecretApprovalPolicy(infisical.CreateSecretApprovalPolicyRequest{

--- a/internal/provider/resource/secret_approval_policy.go
+++ b/internal/provider/resource/secret_approval_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	infisical "terraform-provider-infisical/internal/client"
+	pkg "terraform-provider-infisical/internal/pkg/modifiers"
 	infisicaltf "terraform-provider-infisical/internal/pkg/terraform"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -75,9 +76,10 @@ func (r *secretApprovalPolicyResource) Schema(_ context.Context, _ resource.Sche
 				Optional:    true,
 			},
 			"environment_slugs": schema.ListAttribute{
-				Description: "The environments to apply the secret approval policy to",
-				Optional:    true,
-				ElementType: types.StringType,
+				Description:   "The environments to apply the secret approval policy to",
+				Optional:      true,
+				ElementType:   types.StringType,
+				PlanModifiers: []planmodifier.List{pkg.UnorderedList()},
 			},
 			"secret_path": schema.StringAttribute{
 				Description: "The secret path to apply the secret approval policy to",


### PR DESCRIPTION
Add unorderedListModifier to make sure that the plan does not cause diff in case the elements just change their position. `unorderedListModifier` checks that all elements are equal (from the state and from plan) to make sure a diff is not created without being really needed.  


## How to test 
- go into `examples/resources/infisical_secret_approval_policy` 
- create an approval policy there using `plan` and `apply`. Use more than one environment slug.
- Check the plan again. Check that there is no difference 