### PR TITLE
fix: read secrets by ID to handle folder renames

### DIFF
--- a/internal/provider/resource/secret_resource.go
+++ b/internal/provider/resource/secret_resource.go
@@ -387,14 +387,10 @@ func (r *secretResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	// Get refreshed order value from HashiCups
-	response, err := r.client.GetSingleRawSecretByNameV3(infisical.GetSingleSecretByNameV3Request{
-		SecretName:  state.Name.ValueString(),
-		Type:        "shared",
-		WorkspaceId: state.WorkspaceId.ValueString(),
-		Environment: state.EnvSlug.ValueString(),
-		SecretPath:  state.FolderPath.ValueString(),
-	}, nil)
+	// Read by ID instead of name+path so folder renames don't cause a spurious deletion.
+	response, err := r.client.GetSingleSecretByIDV3(infisical.GetSingleSecretByIDV3Request{
+		ID: state.ID.ValueString(),
+	})
 
 	if err != nil {
 		if err == infisical.ErrNotFound {
@@ -402,7 +398,7 @@ func (r *secretResource) Read(ctx context.Context, req resource.ReadRequest, res
 		} else {
 			resp.Diagnostics.AddError(
 				"Error Reading Infisical secret",
-				"Could not read Infisical secret named "+state.Name.ValueString()+": "+err.Error(),
+				"Could not read Infisical secret with ID "+state.ID.ValueString()+": "+err.Error(),
 			)
 		}
 		return
@@ -410,6 +406,8 @@ func (r *secretResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	state.Name = types.StringValue(response.Secret.SecretKey)
 	state.ID = types.StringValue(response.Secret.ID)
+	state.FolderPath = types.StringValue(response.Secret.SecretPath)
+	state.EnvSlug = types.StringValue(response.Secret.Environment)
 	if !state.Value.IsNull() && !state.Value.IsUnknown() {
 		// Resource was configured with regular Value field
 		state.Value = types.StringValue(response.Secret.SecretValue)


### PR DESCRIPTION
The Read function looked up secrets by name + folder_path + environment. When a folder is renamed server-side (or by another module, i.e. consuming an output), the secret moves with it but Read still uses the old path from state, gets a 404, and silently removes the secret from state. The apply will fail due to trying to use the old folder path.

Switch to GetSingleSecretByIDV3 which uses the immutable secret ID. Also update folder_path and env_slug from the response so state reflects the current server-side location.

Before:
```
Note: Objects have changed outside of OpenTofu

OpenTofu detected the following changes made outside of OpenTofu since the last "tofu apply" which may have affected this plan:

  # infisical_secret.test has been deleted
  - resource "infisical_secret" "test" {
      - id               = "7207b50d-8efa-49a7-bfaa-34894b22a1b1" -> null
        name             = "test_secret"
      - value_wo         = (write-only attribute) -> null
        # (6 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these
changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # infisical_secret.test will be created
  + resource "infisical_secret" "test" {
      + env_slug         = "test"
      + folder_path      = "/provider-test"
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + name             = "test_secret"
      + tag_ids          = []
      + value_wo         = (write-only attribute)
      + value_wo_version = 1
      + workspace_id     = "bf777cda-752e-4394-98b6-ca1702f2a5cc"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
After:
```
Note: Objects have changed outside of OpenTofu

OpenTofu detected the following changes made outside of OpenTofu since the last "tofu apply" which may have affected this plan:

  # infisical_secret.test has changed
  ~ resource "infisical_secret" "test" {
      ~ folder_path      = "/app-settings" -> "/app-config"
        id               = "b46f1191-fb00-41da-ae64-1d60a7909ab6"
        name             = "rename_bug_test"
      ~ value_wo         = (write-only attribute)
        # (5 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these
changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Changes to Outputs:
  ~ secret_folder_path = "/app-settings" -> "/app-config"

You can apply this plan to save these new output values to the OpenTofu state, without changing any real infrastructure.
```