### PR TITLE
fix(secret-approval-policy): Define environments as empty slice 

### DIFF
--- a/internal/provider/resource/secret_approval_policy.go
+++ b/internal/provider/resource/secret_approval_policy.go
@@ -212,6 +212,7 @@ func (r *secretApprovalPolicyResource) Create(ctx context.Context, req resource.
 		environments = infisicaltf.StringListToGoStringSlice(ctx, resp.Diagnostics, plan.EnvironmentSlugs)
 	} else {
 		environment = plan.EnvironmentSlug.ValueString()
+		environments = []string{}
 	}
 
 	secretApprovalPolicy, err := r.client.CreateSecretApprovalPolicy(infisical.CreateSecretApprovalPolicyRequest{

--- a/internal/provider/resource/secret_approval_policy.go
+++ b/internal/provider/resource/secret_approval_policy.go
@@ -363,7 +363,7 @@ func (r *secretApprovalPolicyResource) Update(ctx context.Context, req resource.
 		return
 	}
 
-	if state.EnvironmentSlug != plan.EnvironmentSlug && infisicaltf.IsAttrValueEmpty(plan.EnvironmentSlugs) {
+	if state.EnvironmentSlug != plan.EnvironmentSlug && infisicaltf.IsAttrValueEmpty(plan.EnvironmentSlugs) && infisicaltf.IsAttrValueEmpty(plan.EnvironmentSlug) {
 		resp.Diagnostics.AddError(
 			"Unable to update secret approval policy",
 			fmt.Sprintf("Cannot change environment, previous environment: %s, new environment: %s", state.EnvironmentSlug, plan.EnvironmentSlug),


### PR DESCRIPTION
When the deprecated value is used, we need to define the environments as empty instead of nil, so we don't break the api contract.

If the user sends a `slugs` and later send a `slug`, this can break the update. Changed the provider to also support this. 