### PR TITLE
fix: update documentation and resource descriptions for project idetity specific privilege and project role

### DIFF
--- a/docs/resources/project_identity_specific_privilege.md
+++ b/docs/resources/project_identity_specific_privilege.md
@@ -3,12 +3,12 @@
 page_title: "infisical_project_identity_specific_privilege Resource - terraform-provider-infisical"
 subcategory: "Projects"
 description: |-
-  Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this data source.
+  Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this resource.
 ---
 
 # infisical_project_identity_specific_privilege (Resource)
 
-Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this data source.
+Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this resource.
 
 ## Example Usage
 
@@ -53,15 +53,14 @@ resource "infisical_project_identity_specific_privilege" "test-privilege" {
   permissions_v2 = [
     {
       action   = ["edit"]
-      subject  = "secret-folders",
-      inverted = true,
+      subject  = "secret-folders"
+      inverted = true
     },
     {
-      action  = ["read", "edit"]
-      subject = "secrets",
+      action  = ["describeSecret", "readValue", "edit"]
+      subject = "secrets"
       conditions = jsonencode({
         environment = {
-          "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
         secretPath = {
@@ -85,7 +84,7 @@ resource "infisical_project_identity_specific_privilege" "test-privilege" {
 
 - `is_temporary` (Boolean) Flag to indicate the assigned specific privilege is temporary or not. When is_temporary is true fields temporary_mode, temporary_range and temporary_access_start_time is required.
 - `permission` (Attributes) (DEPRECATED, USE permissions_v2. Refer to the migration guide in https://infisical.com/docs/internals/permissions#migrating-from-permission-v1-to-permission-v2) The permissions assigned to the project identity specific privilege (see [below for nested schema](#nestedatt--permission))
-- `permissions_v2` (Attributes List) The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
+- `permissions_v2` (Attributes List) The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions/project-permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
 - `slug` (String) The slug for the new privilege
 - `temporary_access_end_time` (String) ISO time for which temporary access will end. Computed based on temporary_range and temporary_access_start_time
 - `temporary_access_start_time` (String) ISO time for which temporary access should begin. The current time is used by default.

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -3,12 +3,12 @@
 page_title: "infisical_project_role Resource - terraform-provider-infisical"
 subcategory: "Projects"
 description: |-
-  Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this data source.
+  Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this resource.
 ---
 
 # infisical_project_role (Resource)
 
-Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this data source.
+Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this resource.
 
 ## Example Usage
 
@@ -49,10 +49,9 @@ resource "infisical_project_role" "biller" {
     },
     {
       subject = "secrets"
-      action  = ["read", "edit"]
+      action  = ["describeSecret", "readValue", "edit"]
       conditions = jsonencode({
         environment = {
-          "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
         secretPath = {
@@ -71,7 +70,7 @@ resource "infisical_project_role" "viewer" {
   permissions_v2 = [
     {
       subject = "secrets"
-      action  = ["read"]
+      action  = ["describeSecret", "readValue"]
     },
   ]
 }
@@ -89,7 +88,7 @@ resource "infisical_project_role" "viewer" {
 
 - `description` (String) The description for the new role. Defaults to an empty string.
 - `permissions` (Attributes List) (DEPRECATED, USE permissions_v2. Refer to the migration guide in https://infisical.com/docs/internals/permissions#migrating-from-permission-v1-to-permission-v2) The permissions assigned to the project role (see [below for nested schema](#nestedatt--permissions))
-- `permissions_v2` (Attributes List) The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
+- `permissions_v2` (Attributes List) The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions/project-permissions for its usage. (see [below for nested schema](#nestedatt--permissions_v2))
 - `project_id` (String) The ID of the project to create role. Must provide either project_id or project_slug, but not both.
 - `project_slug` (String) The slug of the project to create role. Must provide either project_slug or project_id, but not both.
 

--- a/examples/resources/infisical_project_identity_specific_privilege/resource.tf
+++ b/examples/resources/infisical_project_identity_specific_privilege/resource.tf
@@ -38,15 +38,14 @@ resource "infisical_project_identity_specific_privilege" "test-privilege" {
   permissions_v2 = [
     {
       action   = ["edit"]
-      subject  = "secret-folders",
-      inverted = true,
+      subject  = "secret-folders"
+      inverted = true
     },
     {
-      action  = ["read", "edit"]
-      subject = "secrets",
+      action  = ["describeSecret", "readValue", "edit"]
+      subject = "secrets"
       conditions = jsonencode({
         environment = {
-          "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
         secretPath = {

--- a/examples/resources/infisical_project_role/resource.tf
+++ b/examples/resources/infisical_project_role/resource.tf
@@ -34,10 +34,9 @@ resource "infisical_project_role" "biller" {
     },
     {
       subject = "secrets"
-      action  = ["read", "edit"]
+      action  = ["describeSecret", "readValue", "edit"]
       conditions = jsonencode({
         environment = {
-          "$in" = ["dev", "prod"]
           "$eq" = "dev"
         }
         secretPath = {
@@ -56,7 +55,7 @@ resource "infisical_project_role" "viewer" {
   permissions_v2 = [
     {
       subject = "secrets"
-      action  = ["read"]
+      action  = ["describeSecret", "readValue"]
     },
   ]
 }

--- a/internal/provider/resource/project_identity_specific_privilege.go
+++ b/internal/provider/resource/project_identity_specific_privilege.go
@@ -81,7 +81,7 @@ func (r *projectIdentitySpecificPrivilegeResourceResource) Metadata(_ context.Co
 // Schema defines the schema for the resource.
 func (r *projectIdentitySpecificPrivilegeResourceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this data source.",
+		Description: "Create additional privileges for identities & save to Infisical. Only Machine Identity authentication is supported for this resource.",
 		Attributes: map[string]schema.Attribute{
 			"identity_id": schema.StringAttribute{
 				Description: "The identity id to create identity specific privilege",
@@ -166,7 +166,7 @@ func (r *projectIdentitySpecificPrivilegeResourceResource) Schema(_ context.Cont
 			},
 			"permissions_v2": schema.ListNestedAttribute{
 				Optional:    true,
-				Description: "The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage.",
+				Description: "The permissions assigned to the project identity specific privilege. Refer to the documentation here https://infisical.com/docs/internals/permissions/project-permissions for its usage.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"action": schema.SetAttribute{

--- a/internal/provider/resource/project_role_resource.go
+++ b/internal/provider/resource/project_role_resource.go
@@ -91,7 +91,7 @@ var permissionsObjectType = types.ObjectType{
 // Schema defines the schema for the resource.
 func (r *projectRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this data source.",
+		Description: "Create custom project roles & save to Infisical. Only Machine Identity authentication is supported for this resource.",
 		Attributes: map[string]schema.Attribute{
 			"slug": schema.StringAttribute{
 				Description: "The slug for the new role",
@@ -137,7 +137,7 @@ func (r *projectRoleResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"permissions_v2": schema.ListNestedAttribute{
 				Optional:    true,
-				Description: "The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions for its usage.",
+				Description: "The permissions assigned to the project role. Refer to the documentation here https://infisical.com/docs/internals/permissions/project-permissions for its usage.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"action": schema.SetAttribute{


### PR DESCRIPTION
Updates Terraform docs and examples for infisical_project_identity_specific_privilege and infisical_project_role so secret access uses granular permissions_v2 actions (describeSecret, readValue) instead of legacy read, and links to [Project permissions](https://infisical.com/docs/internals/permissions/project-permissions). Fixes wording (resource, not data source) and matches examples/ to the published pages. Schema descriptions updated so future docgen stays aligned.

Verify: terraform validate on a config using permissions_v2 with subject = "secrets" and action = ["describeSecret", "readValue"].