### PR TITLE
fix: guard GetGroupById against empty ID 

### DIFF
--- a/internal/client/group.go
+++ b/internal/client/group.go
@@ -74,6 +74,10 @@ func (client Client) DeleteGroup(request DeleteGroupRequest) (Group, error) {
 }
 
 func (client Client) GetGroupById(request GetGroupByIdRequest) (Group, error) {
+	if request.ID == "" {
+		return Group{}, ErrNotFound
+	}
+
 	var groupResponse Group
 	response, err := client.Config.HttpClient.
 		R().


### PR DESCRIPTION
GetGroupById now returns ErrNotFound when ID is empty, so callers don’t hit the API with an invalid identifier.