### PR TITLE
fix(secrets): add write only prefix on import

### DIFF
--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -113,3 +113,21 @@ Required:
 Optional:
 
 - `note` (String) Note for the secret rotation reminder
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Import by Infisical secret UUID. The secret value is written to state under `value`.
+terraform import infisical_secret.example <secret_id>
+
+# Import by workspace, environment, folder path, and secret name. The secret value is written to state under `value`.
+terraform import infisical_secret.example '<workspace_id>:<env_slug>:<folder_path>:<secret_name>'
+
+# Import as write-only by prefixing the ID with `write-only:`. The secret value is NOT written to state; `value_wo_version` is initialized to 1 so a config with `value_wo_version = 1` will not trigger a spurious update on the first plan.
+terraform import infisical_secret.example 'write-only:<secret_id>'
+
+# The write-only prefix also works with the composite format.
+terraform import infisical_secret.example 'write-only:<workspace_id>:<env_slug>:<folder_path>:<secret_name>'
+```

--- a/examples/resources/infisical_secret/import.sh
+++ b/examples/resources/infisical_secret/import.sh
@@ -1,0 +1,11 @@
+# Import by Infisical secret UUID. The secret value is written to state under `value`.
+terraform import infisical_secret.example <secret_id>
+
+# Import by workspace, environment, folder path, and secret name. The secret value is written to state under `value`.
+terraform import infisical_secret.example '<workspace_id>:<env_slug>:<folder_path>:<secret_name>'
+
+# Import as write-only by prefixing the ID with `write-only:`. The secret value is NOT written to state; `value_wo_version` is initialized to 1 so a config with `value_wo_version = 1` will not trigger a spurious update on the first plan.
+terraform import infisical_secret.example 'write-only:<secret_id>'
+
+# The write-only prefix also works with the composite format.
+terraform import infisical_secret.example 'write-only:<workspace_id>:<env_slug>:<folder_path>:<secret_name>'

--- a/internal/provider/resource/secret_resource.go
+++ b/internal/provider/resource/secret_resource.go
@@ -639,9 +639,25 @@ func (r *secretResource) ImportState(ctx context.Context, req resource.ImportSta
 	var secretReminder SecretReminder
 	var secretMetadata []infisical.SecretMetadataItem
 
-	if _, err := uuid.ParseUUID(req.ID); err == nil {
+	const writeOnlyPrefix = "write-only:"
+	isWriteOnly := false
+	importID := req.ID
+
+	if strings.HasPrefix(req.ID, writeOnlyPrefix) {
+		isWriteOnly = true
+		importID = strings.TrimPrefix(req.ID, writeOnlyPrefix)
+		if importID == "" {
+			resp.Diagnostics.AddError(
+				"Invalid Import ID",
+				"The import ID after the 'write-only:' prefix must not be empty. Expected 'write-only:<uuid>' or 'write-only:<workspace>:<env>:<secret-path>:<secret-name>'.",
+			)
+			return
+		}
+	}
+
+	if _, err := uuid.ParseUUID(importID); err == nil {
 		secret, err := r.client.GetSingleSecretByIDV3(infisical.GetSingleSecretByIDV3Request{
-			ID: req.ID,
+			ID: importID,
 		})
 
 		if err != nil {
@@ -674,7 +690,7 @@ func (r *secretResource) ImportState(ctx context.Context, req resource.ImportSta
 		secretId = secret.Secret.ID
 		secretMetadata = secret.Secret.SecretMetadata
 	} else {
-		parts := strings.SplitN(req.ID, ":", 4)
+		parts := strings.SplitN(importID, ":", 4)
 
 		if len(parts) != 4 {
 			resp.Diagnostics.AddError(
@@ -728,7 +744,11 @@ func (r *secretResource) ImportState(ctx context.Context, req resource.ImportSta
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("env_slug"), environment)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("folder_path"), secretPath)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), secretName)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("value"), secretValue)...)
+	if isWriteOnly {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("value_wo_version"), types.Int64Value(1))...)
+	} else {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("value"), secretValue)...)
+	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("tag_ids"), tags)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("secret_reminder"), secretReminder)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), secretId)...)


### PR DESCRIPTION
### How to test 

- create a new project with secrets inside Infisical 
- try to import a secret using `terraform import infisical_secret.<secret-name-inside-terraform> <secret-id>`
- Check that the state has the value written as `sensitive value`