### PR TITLE
improvement(app-connections): add support for gateways

### DIFF
--- a/docs/resources/app_connection_1password.md
+++ b/docs/resources/app_connection_1password.md
@@ -55,6 +55,7 @@ resource "infisical_app_connection_1password" "one-password-demo" {
 ### Optional
 
 - `description` (String) An optional description for the 1Password App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_aws.md
+++ b/docs/resources/app_connection_aws.md
@@ -64,6 +64,7 @@ resource "infisical_app_connection_aws" "app-connection-aws-access-key" {
 ### Optional
 
 - `description` (String) An optional description for the AWS App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_azure_app_configuration.md
+++ b/docs/resources/app_connection_azure_app_configuration.md
@@ -56,6 +56,7 @@ resource "infisical_app_connection_azure_app_configuration" "app_connection_azur
 ### Optional
 
 - `description` (String) An optional description for the Azure App Configuration App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_azure_client_secrets.md
+++ b/docs/resources/app_connection_azure_client_secrets.md
@@ -56,6 +56,7 @@ resource "infisical_app_connection_azure_client_secrets" "app_connection_azure_c
 ### Optional
 
 - `description` (String) An optional description for the Azure Client Secrets App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_azure_devops.md
+++ b/docs/resources/app_connection_azure_devops.md
@@ -67,6 +67,7 @@ resource "infisical_app_connection_azure_devops" "app_connection_azure_devops_ac
 ### Optional
 
 - `description` (String) An optional description for the Azure DevOps App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_azure_key_vault.md
+++ b/docs/resources/app_connection_azure_key_vault.md
@@ -56,6 +56,7 @@ resource "infisical_app_connection_azure_key_vault" "app_connection_azure_key_va
 ### Optional
 
 - `description` (String) An optional description for the Azure Key Vault App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_bitbucket.md
+++ b/docs/resources/app_connection_bitbucket.md
@@ -56,6 +56,7 @@ resource "infisical_app_connection_bitbucket" "example" {
 ### Optional
 
 - `description` (String) An optional description for the Bitbucket App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_cloudflare.md
+++ b/docs/resources/app_connection_cloudflare.md
@@ -55,6 +55,7 @@ resource "infisical_app_connection_cloudflare" "app-connection-cloudflare" {
 ### Optional
 
 - `description` (String) An optional description for the Cloudflare App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_databricks.md
+++ b/docs/resources/app_connection_databricks.md
@@ -57,6 +57,7 @@ resource "infisical_app_connection_databricks" "example" {
 ### Optional
 
 - `description` (String) An optional description for the Databricks App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_flyio.md
+++ b/docs/resources/app_connection_flyio.md
@@ -55,6 +55,7 @@ resource "infisical_app_connection_flyio" "example" {
 ### Optional
 
 - `description` (String) An optional description for the Fly.io App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_gcp.md
+++ b/docs/resources/app_connection_gcp.md
@@ -54,6 +54,7 @@ resource "infisical_app_connection_gcp" "app-connection-gcp" {
 ### Optional
 
 - `description` (String) An optional description for the GCP App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_github.md
+++ b/docs/resources/app_connection_github.md
@@ -57,6 +57,7 @@ resource "infisical_app_connection_github" "github_connection" {
 ### Optional
 
 - `description` (String) An optional description for the GitHub App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_gitlab.md
+++ b/docs/resources/app_connection_gitlab.md
@@ -57,6 +57,7 @@ resource "infisical_app_connection_gitlab" "gitlab_connection" {
 ### Optional
 
 - `description` (String) An optional description for the GitLab App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_hashicorp_vault.md
+++ b/docs/resources/app_connection_hashicorp_vault.md
@@ -36,11 +36,12 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-access
   name   = "vault-access-token-app-connection"
   method = "access-token"
   credentials = {
-    instance_url = "https://vault.example.com"
+    instance_url = "<vault-instance-url>"
     access_token = "<vault-access-token>"
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
-  # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+
+  gateway_id  = "<gateway-id>" # Optional, only required if you want to use a specific gateway
   description = "I am a test app connection"
 }
 
@@ -54,6 +55,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  gateway_id  = "<gateway-id>" # Optional, only required if you want to use a specific gateway
   description = "I am a test app connection"
 }
 ```
@@ -70,6 +72,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
 ### Optional
 
 - `description` (String) An optional description for the HashiCorp Vault App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_ldap.md
+++ b/docs/resources/app_connection_ldap.md
@@ -73,6 +73,7 @@ resource "infisical_app_connection_ldap" "ldap-demo-secure" {
 ### Optional
 
 - `description` (String) An optional description for the LDAP App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_mssql.md
+++ b/docs/resources/app_connection_mssql.md
@@ -59,6 +59,7 @@ resource "infisical_app_connection_mssql" "mssql-demo" {
 ### Optional
 
 - `description` (String) An optional description for the MsSQL App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_mysql.md
+++ b/docs/resources/app_connection_mysql.md
@@ -59,6 +59,7 @@ resource "infisical_app_connection_mysql" "mysql-demo" {
 ### Optional
 
 - `description` (String) An optional description for the MySQL App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_oracledb.md
+++ b/docs/resources/app_connection_oracledb.md
@@ -59,6 +59,7 @@ resource "infisical_app_connection_oracledb" "oracledb-demo" {
 ### Optional
 
 - `description` (String) An optional description for the Oracle Database App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_postgres.md
+++ b/docs/resources/app_connection_postgres.md
@@ -59,6 +59,7 @@ resource "infisical_app_connection_postgres" "postgres-demo" {
 ### Optional
 
 - `description` (String) An optional description for the PostgreSQL App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_render.md
+++ b/docs/resources/app_connection_render.md
@@ -54,6 +54,7 @@ resource "infisical_app_connection_render" "render-demo" {
 ### Optional
 
 - `description` (String) An optional description for the Render App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/docs/resources/app_connection_supabase.md
+++ b/docs/resources/app_connection_supabase.md
@@ -56,6 +56,7 @@ resource "infisical_app_connection_supabase" "example" {
 ### Optional
 
 - `description` (String) An optional description for the Supabase App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/examples/resources/infisical_app_connection_hashicorp_vault/resource.tf
+++ b/examples/resources/infisical_app_connection_hashicorp_vault/resource.tf
@@ -21,11 +21,12 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-access
   name   = "vault-access-token-app-connection"
   method = "access-token"
   credentials = {
-    instance_url = "https://vault.example.com"
+    instance_url = "<vault-instance-url>"
     access_token = "<vault-access-token>"
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
-  # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+
+  gateway_id  = "<gateway-id>" # Optional, only required if you want to use a specific gateway
   description = "I am a test app connection"
 }
 
@@ -39,5 +40,6 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  gateway_id  = "<gateway-id>" # Optional, only required if you want to use a specific gateway
   description = "I am a test app connection"
 }

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2223,6 +2223,7 @@ type AppConnection struct {
 	App             string  `json:"app"`
 	Method          string  `json:"method"`
 	CredentialsHash string  `json:"credentialsHash"`
+	GatewayId       *string `json:"gatewayId"`
 }
 
 type CreateAppConnectionRequest struct {
@@ -2232,6 +2233,7 @@ type CreateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   *string                `json:"gatewayId"`
 }
 
 type CreateAppConnectionResponse struct {
@@ -2255,6 +2257,7 @@ type UpdateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials,omitempty"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   *string                `json:"gatewayId"`
 }
 
 type UpdateAppConnectionResponse struct {

--- a/internal/provider/resource/app_connection/app_connection_hashicorp_vault.go
+++ b/internal/provider/resource/app_connection/app_connection_hashicorp_vault.go
@@ -28,6 +28,7 @@ func NewAppConnectionHashicorpVaultResource() resource.Resource {
 		App:               infisical.AppConnectionAppHashicorpVault,
 		AppConnectionName: "HashiCorp Vault",
 		ResourceTypeName:  "_app_connection_hashicorp_vault",
+		SupportsGateway:   true,
 		AllowedMethods:    []string{HashicorpVaultAppConnectionAccessTokenMethod, HashicorpVaultAppConnectionAppRoleMethod},
 		CredentialsAttributes: map[string]schema.Attribute{
 			"instance_url": schema.StringAttribute{

--- a/internal/provider/resource/app_connection/base_app_connection.go
+++ b/internal/provider/resource/app_connection/base_app_connection.go
@@ -123,50 +123,45 @@ func (r *AppConnectionBaseResource) Metadata(_ context.Context, req resource.Met
 }
 
 func (r *AppConnectionBaseResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	attributes := map[string]schema.Attribute{
-		"id": schema.StringAttribute{
-			Description:   "The ID of the app connection",
-			Computed:      true,
-			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-		},
-		"method": schema.StringAttribute{
-			Required:    true,
-			Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
-		},
-		"name": schema.StringAttribute{
-			Required:    true,
-			Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
-		},
-		"description": schema.StringAttribute{
-			Optional:    true,
-			Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
-		},
-		"project_id": schema.StringAttribute{
-			Optional:      true,
-			Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
-			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-		},
-		"credentials": schema.SingleNestedAttribute{
-			Required:    true,
-			Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
-			Attributes:  r.CredentialsAttributes,
-		},
-		"credentials_hash": schema.StringAttribute{
-			Computed:    true,
-			Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
-		},
-	}
-
-	if r.SupportsGateway {
-		attributes["gateway_id"] = schema.StringAttribute{
-			Optional:    true,
-			Description: "The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.",
-		}
-	}
-
 	resp.Schema = schema.Schema{
 		Description: fmt.Sprintf("Create and manage %s App Connection", r.AppConnectionName),
-		Attributes:  attributes,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "The ID of the app connection",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"method": schema.StringAttribute{
+				Required:    true,
+				Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
+			},
+			"description": schema.StringAttribute{
+				Optional:    true,
+				Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
+			},
+			"project_id": schema.StringAttribute{
+				Optional:      true,
+				Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+			},
+			"credentials": schema.SingleNestedAttribute{
+				Required:    true,
+				Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
+				Attributes:  r.CredentialsAttributes,
+			},
+			"credentials_hash": schema.StringAttribute{
+				Computed:    true,
+				Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
+			},
+			"gateway_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.",
+			},
+		},
 	}
 }
 

--- a/internal/provider/resource/app_connection/base_app_connection.go
+++ b/internal/provider/resource/app_connection/base_app_connection.go
@@ -22,6 +22,7 @@ type AppConnectionBaseResource struct {
 	App                              infisical.AppConnectionApp // used for identifying secret sync route
 	ResourceTypeName                 string                     // terraform resource name suffix
 	AppConnectionName                string                     // complete descriptive name of the app connection
+	SupportsGateway                  bool                       // when true, exposes gateway_id on the resource
 	client                           *infisical.Client
 	AllowedMethods                   []string
 	CredentialsAttributes            map[string]schema.Attribute
@@ -96,6 +97,24 @@ type AppConnectionBaseResourceModel struct {
 	ProjectId       types.String `tfsdk:"project_id"`
 	Credentials     types.Object `tfsdk:"credentials"`
 	CredentialsHash types.String `tfsdk:"credentials_hash"`
+	GatewayId       types.String `tfsdk:"gateway_id"`
+}
+
+// gatewayIdForRequest returns the gateway_id value to send to the API.
+// It returns a non-nil pointer only when the resource supports gateways and a
+// value is set. When the gateway has been removed from the configuration it
+// returns nil, which serializes to an explicit `null` so the API resets the
+// connection back to the Internet Gateway (omitting the field would leave the
+// existing gateway untouched).
+func (r *AppConnectionBaseResource) gatewayIdForRequest(gatewayId types.String) *string {
+	if !r.SupportsGateway {
+		return nil
+	}
+	if gatewayId.IsNull() || gatewayId.IsUnknown() || gatewayId.ValueString() == "" {
+		return nil
+	}
+	value := gatewayId.ValueString()
+	return &value
 }
 
 // Metadata returns the resource type name.
@@ -104,41 +123,50 @@ func (r *AppConnectionBaseResource) Metadata(_ context.Context, req resource.Met
 }
 
 func (r *AppConnectionBaseResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	attributes := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description:   "The ID of the app connection",
+			Computed:      true,
+			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+		"method": schema.StringAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
+		},
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
+		},
+		"project_id": schema.StringAttribute{
+			Optional:      true,
+			Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+		},
+		"credentials": schema.SingleNestedAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
+			Attributes:  r.CredentialsAttributes,
+		},
+		"credentials_hash": schema.StringAttribute{
+			Computed:    true,
+			Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
+		},
+	}
+
+	if r.SupportsGateway {
+		attributes["gateway_id"] = schema.StringAttribute{
+			Optional:    true,
+			Description: "The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.",
+		}
+	}
+
 	resp.Schema = schema.Schema{
 		Description: fmt.Sprintf("Create and manage %s App Connection", r.AppConnectionName),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Description:   "The ID of the app connection",
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-			},
-			"method": schema.StringAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
-			},
-			"name": schema.StringAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
-			},
-			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
-			},
-			"project_id": schema.StringAttribute{
-				Optional:      true,
-				Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-			},
-			"credentials": schema.SingleNestedAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
-				Attributes:  r.CredentialsAttributes,
-			},
-			"credentials_hash": schema.StringAttribute{
-				Computed:    true,
-				Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
-			},
-		},
+		Attributes:  attributes,
 	}
 }
 
@@ -212,6 +240,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
+			GatewayId:   r.gatewayIdForRequest(plan.GatewayId),
 		})
 		return apiErr
 	})
@@ -298,6 +327,14 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 		state.ProjectId = types.StringNull()
 	}
 
+	if r.SupportsGateway {
+		if appConnection.GatewayId != nil {
+			state.GatewayId = types.StringValue(*appConnection.GatewayId)
+		} else {
+			state.GatewayId = types.StringNull()
+		}
+	}
+
 	state.Method = types.StringValue(appConnection.Method)
 	state.Name = types.StringValue(appConnection.Name)
 
@@ -362,6 +399,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
+			GatewayId:   r.gatewayIdForRequest(plan.GatewayId),
 		})
 		return apiErr
 	})


### PR DESCRIPTION
This changes the base app connection file to allow the creation of app connections. 

Test: 
- start a vault instance locally 
- try to create an app connection using the resource.tf example from the vault app connection 
- First create it without gateway 
- Update it (add the gateway)
- remove the gateway 
- Make sure that the changes are being reflected inside infisical. 