### PR TITLE
feat(app-connections): add support for gateway

### DIFF
--- a/docs/resources/app_connection_hashicorp_vault.md
+++ b/docs/resources/app_connection_hashicorp_vault.md
@@ -41,6 +41,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-access
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  # gateway_id   = "<gateway-id>" # Optional, route through a specific Infisical Gateway instead of the Internet Gateway
   description = "I am a test app connection"
 }
 
@@ -54,6 +55,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  # gateway_id   = "<gateway-id>" # Optional, route through a specific Infisical Gateway instead of the Internet Gateway
   description = "I am a test app connection"
 }
 ```
@@ -70,6 +72,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
 ### Optional
 
 - `description` (String) An optional description for the HashiCorp Vault App Connection.
+- `gateway_id` (String) The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.
 - `project_id` (String) The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.
 
 ### Read-Only

--- a/examples/resources/infisical_app_connection_hashicorp_vault/resource.tf
+++ b/examples/resources/infisical_app_connection_hashicorp_vault/resource.tf
@@ -26,6 +26,7 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-access
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  # gateway_id   = "<gateway-id>" # Optional, route through a specific Infisical Gateway instead of the Internet Gateway
   description = "I am a test app connection"
 }
 
@@ -39,5 +40,6 @@ resource "infisical_app_connection_hashicorp_vault" "app-connection-vault-app-ro
     # namespace  = "<namespace>" # Optional, only for HCP Vault Dedicated/Enterprise
   }
   # project_id   = "<project-id>" # Optional, only required if you want to scope the app connection to a specific project
+  # gateway_id   = "<gateway-id>" # Optional, route through a specific Infisical Gateway instead of the Internet Gateway
   description = "I am a test app connection"
 }

--- a/internal/client/app_connection.go
+++ b/internal/client/app_connection.go
@@ -40,14 +40,17 @@ const (
 )
 
 const (
-	operationCreateAppConnection  = "CallCreateAppConnection"
-	operationGetAppConnectionById = "CallGetAppConnectionById"
-	operationUpdateAppConnection  = "CallUpdateAppConnection"
-	operationDeleteAppConnection  = "CallDeleteAppConnection"
+	operationCreateAppConnection            = "CallCreateAppConnection"
+	operationGetAppConnectionById           = "CallGetAppConnectionById"
+	operationUpdateAppConnection            = "CallUpdateAppConnection"
+	operationDeleteAppConnection            = "CallDeleteAppConnection"
+	operationCreateAppConnectionWithGateway = "CallCreateAppConnectionWithGateway"
+	operationUpdateAppConnectionWithGateway = "CallUpdateAppConnectionWithGateway"
 )
 
 func (client Client) CreateAppConnection(request CreateAppConnectionRequest) (AppConnection, error) {
 	var body CreateAppConnectionResponse
+
 	response, err := client.Config.HttpClient.
 		R().
 		SetResult(&body).
@@ -61,6 +64,27 @@ func (client Client) CreateAppConnection(request CreateAppConnectionRequest) (Ap
 
 	if response.IsError() {
 		return AppConnection{}, errors.NewAPIErrorWithResponse(operationCreateAppConnection, response, nil)
+	}
+
+	return body.AppConnection, nil
+}
+
+func (client Client) CreateAppConnectionWithGateway(request CreateAppConnectionWithGateway) (AppConnection, error) {
+	var body CreateAppConnectionResponse
+
+	response, err := client.Config.HttpClient.
+		R().
+		SetResult(&body).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Post("api/v1/app-connections/" + string(request.App))
+
+	if err != nil {
+		return AppConnection{}, errors.NewGenericRequestError(operationCreateAppConnectionWithGateway, err)
+	}
+
+	if response.IsError() {
+		return AppConnection{}, errors.NewAPIErrorWithResponse(operationCreateAppConnectionWithGateway, response, nil)
 	}
 
 	return body.AppConnection, nil
@@ -103,6 +127,27 @@ func (client Client) UpdateAppConnection(request UpdateAppConnectionRequest) (Ap
 
 	if response.IsError() {
 		return AppConnection{}, errors.NewAPIErrorWithResponse(operationUpdateAppConnection, response, nil)
+	}
+
+	return body.AppConnection, nil
+}
+
+func (client Client) UpdateAppConnectionWithGateway(request UpdateAppConnectionWithGateway) (AppConnection, error) {
+	var body UpdateAppConnectionResponse
+
+	response, err := client.Config.HttpClient.
+		R().
+		SetResult(&body).
+		SetHeader("User-Agent", USER_AGENT).
+		SetBody(request).
+		Patch(fmt.Sprintf("api/v1/app-connections/%s/%s", request.App, request.ID))
+
+	if err != nil {
+		return AppConnection{}, errors.NewGenericRequestError(operationUpdateAppConnectionWithGateway, err)
+	}
+
+	if response.IsError() {
+		return AppConnection{}, errors.NewAPIErrorWithResponse(operationUpdateAppConnectionWithGateway, response, nil)
 	}
 
 	return body.AppConnection, nil

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2233,7 +2233,11 @@ type CreateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials"`
 	ProjectId   string                 `json:"projectId,omitempty"`
-	GatewayId   *string                `json:"gatewayId"`
+}
+
+type CreateAppConnectionWithGateway struct {
+	CreateAppConnectionRequest
+	GatewayId *string `json:"gatewayId"`
 }
 
 type CreateAppConnectionResponse struct {
@@ -2257,7 +2261,11 @@ type UpdateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials,omitempty"`
 	ProjectId   string                 `json:"projectId,omitempty"`
-	GatewayId   *string                `json:"gatewayId"`
+}
+
+type UpdateAppConnectionWithGateway struct {
+	UpdateAppConnectionRequest
+	GatewayId *string `json:"gatewayId"`
 }
 
 type UpdateAppConnectionResponse struct {

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -2223,6 +2223,7 @@ type AppConnection struct {
 	App             string  `json:"app"`
 	Method          string  `json:"method"`
 	CredentialsHash string  `json:"credentialsHash"`
+	GatewayId       *string `json:"gatewayId"`
 }
 
 type CreateAppConnectionRequest struct {
@@ -2232,6 +2233,7 @@ type CreateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   *string                `json:"gatewayId"`
 }
 
 type CreateAppConnectionResponse struct {
@@ -2255,6 +2257,7 @@ type UpdateAppConnectionRequest struct {
 	Name        string                 `json:"name"`
 	Credentials map[string]interface{} `json:"credentials,omitempty"`
 	ProjectId   string                 `json:"projectId,omitempty"`
+	GatewayId   *string                `json:"gatewayId"`
 }
 
 type UpdateAppConnectionResponse struct {

--- a/internal/provider/resource/app_connection/app_connection_hashicorp_vault.go
+++ b/internal/provider/resource/app_connection/app_connection_hashicorp_vault.go
@@ -28,6 +28,7 @@ func NewAppConnectionHashicorpVaultResource() resource.Resource {
 		App:               infisical.AppConnectionAppHashicorpVault,
 		AppConnectionName: "HashiCorp Vault",
 		ResourceTypeName:  "_app_connection_hashicorp_vault",
+		SupportsGateway:   true,
 		AllowedMethods:    []string{HashicorpVaultAppConnectionAccessTokenMethod, HashicorpVaultAppConnectionAppRoleMethod},
 		CredentialsAttributes: map[string]schema.Attribute{
 			"instance_url": schema.StringAttribute{

--- a/internal/provider/resource/app_connection/base_app_connection.go
+++ b/internal/provider/resource/app_connection/base_app_connection.go
@@ -9,11 +9,13 @@ import (
 	infisical "terraform-provider-infisical/internal/client"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -212,6 +214,9 @@ func (r *AppConnectionBaseResource) Schema(_ context.Context, _ resource.SchemaR
 		attributes["gateway_id"] = schema.StringAttribute{
 			Optional:    true,
 			Description: "The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+			},
 		}
 	}
 
@@ -283,15 +288,23 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 	var appConnection infisical.AppConnection
 	err := retryAppConnectionOp(ctx, r.IsRetryableError, func() error {
 		var apiErr error
-		appConnection, apiErr = r.client.CreateAppConnection(infisical.CreateAppConnectionRequest{
+		baseRequest := infisical.CreateAppConnectionRequest{
 			App:         r.App,
 			Name:        plan.Name.ValueString(),
 			Description: plan.Description.ValueString(),
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
-			GatewayId:   r.gatewayIdForRequest(gatewayId),
-		})
+		}
+
+		if r.SupportsGateway {
+			appConnection, apiErr = r.client.CreateAppConnectionWithGateway(infisical.CreateAppConnectionWithGateway{
+				CreateAppConnectionRequest: baseRequest,
+				GatewayId:                  r.gatewayIdForRequest(gatewayId),
+			})
+		} else {
+			appConnection, apiErr = r.client.CreateAppConnection(baseRequest)
+		}
 		return apiErr
 	})
 
@@ -305,6 +318,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 
 	plan.ID = types.StringValue(appConnection.Id)
 	plan.CredentialsHash = types.StringValue(appConnection.CredentialsHash)
+	gatewayId = r.reconcileGatewayId(gatewayId, appConnection)
 
 	diags = resp.State.Set(ctx, r.stateValue(plan, gatewayId))
 	resp.Diagnostics.Append(diags...)
@@ -433,7 +447,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 	var appConnection infisical.AppConnection
 	err := retryAppConnectionOp(ctx, r.IsRetryableError, func() error {
 		var apiErr error
-		appConnection, apiErr = r.client.UpdateAppConnection(infisical.UpdateAppConnectionRequest{
+		baseRequest := infisical.UpdateAppConnectionRequest{
 			ID:          state.ID.ValueString(),
 			App:         r.App,
 			Name:        plan.Name.ValueString(),
@@ -441,8 +455,16 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
-			GatewayId:   r.gatewayIdForRequest(gatewayId),
-		})
+		}
+
+		if r.SupportsGateway {
+			appConnection, apiErr = r.client.UpdateAppConnectionWithGateway(infisical.UpdateAppConnectionWithGateway{
+				UpdateAppConnectionRequest: baseRequest,
+				GatewayId:                  r.gatewayIdForRequest(gatewayId),
+			})
+		} else {
+			appConnection, apiErr = r.client.UpdateAppConnection(baseRequest)
+		}
 		return apiErr
 	})
 
@@ -455,6 +477,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	plan.CredentialsHash = types.StringValue(appConnection.CredentialsHash)
+	gatewayId = r.reconcileGatewayId(gatewayId, appConnection)
 
 	diags = resp.State.Set(ctx, r.stateValue(plan, gatewayId))
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource/app_connection/base_app_connection.go
+++ b/internal/provider/resource/app_connection/base_app_connection.go
@@ -22,6 +22,7 @@ type AppConnectionBaseResource struct {
 	App                              infisical.AppConnectionApp // used for identifying secret sync route
 	ResourceTypeName                 string                     // terraform resource name suffix
 	AppConnectionName                string                     // complete descriptive name of the app connection
+	SupportsGateway                  bool                       // when true, exposes gateway_id and sends it to the API
 	client                           *infisical.Client
 	AllowedMethods                   []string
 	CredentialsAttributes            map[string]schema.Attribute
@@ -98,47 +99,125 @@ type AppConnectionBaseResourceModel struct {
 	CredentialsHash types.String `tfsdk:"credentials_hash"`
 }
 
+// appConnectionGatewayResourceModel is used for plan/state I/O on connections that support
+// gateways. The embedded base model's tfsdk fields are promoted, so this matches the schema
+// that includes gateway_id. Connections without gateway support keep using the base model
+// directly, leaving their schema untouched.
+type appConnectionGatewayResourceModel struct {
+	AppConnectionBaseResourceModel
+	GatewayId types.String `tfsdk:"gateway_id"`
+}
+
+// planStateGetter is satisfied by both tfsdk.Plan and tfsdk.State (value receivers), letting
+// readModel handle plan and state reads uniformly.
+type planStateGetter interface {
+	Get(ctx context.Context, target interface{}) diag.Diagnostics
+}
+
+// readModel reads plan/state into the base model. For gateway-enabled connections it also
+// returns the configured gateway_id; otherwise that value is null.
+func (r *AppConnectionBaseResource) readModel(ctx context.Context, src planStateGetter) (AppConnectionBaseResourceModel, types.String, diag.Diagnostics) {
+	if r.SupportsGateway {
+		var m appConnectionGatewayResourceModel
+		diags := src.Get(ctx, &m)
+		return m.AppConnectionBaseResourceModel, m.GatewayId, diags
+	}
+
+	var m AppConnectionBaseResourceModel
+	diags := src.Get(ctx, &m)
+	return m, types.StringNull(), diags
+}
+
+// stateValue returns the value to write to state, gateway-aware when the connection supports
+// gateways so the struct matches the schema (which then includes gateway_id).
+func (r *AppConnectionBaseResource) stateValue(model AppConnectionBaseResourceModel, gatewayId types.String) interface{} {
+	if r.SupportsGateway {
+		return appConnectionGatewayResourceModel{
+			AppConnectionBaseResourceModel: model,
+			GatewayId:                      gatewayId,
+		}
+	}
+	return model
+}
+
+// reconcileGatewayId returns the gateway_id to persist from the API response. For connections
+// that don't support gateways it leaves the current value untouched.
+func (r *AppConnectionBaseResource) reconcileGatewayId(current types.String, appConnection infisical.AppConnection) types.String {
+	if !r.SupportsGateway {
+		return current
+	}
+	if appConnection.GatewayId != nil {
+		return types.StringValue(*appConnection.GatewayId)
+	}
+	return types.StringNull()
+}
+
+// gatewayIdForRequest returns the gateway_id value to send to the API. It returns a non-nil
+// pointer only when the resource supports gateways and a value is set. When the gateway has
+// been removed from the configuration it returns nil, which serializes to an explicit `null`
+// so the API resets the connection back to the Internet Gateway (omitting the field would
+// leave the existing gateway untouched).
+func (r *AppConnectionBaseResource) gatewayIdForRequest(gatewayId types.String) *string {
+	if !r.SupportsGateway {
+		return nil
+	}
+	if gatewayId.IsNull() || gatewayId.IsUnknown() || gatewayId.ValueString() == "" {
+		return nil
+	}
+	value := gatewayId.ValueString()
+	return &value
+}
+
 // Metadata returns the resource type name.
 func (r *AppConnectionBaseResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + r.ResourceTypeName
 }
 
 func (r *AppConnectionBaseResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	attributes := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Description:   "The ID of the app connection",
+			Computed:      true,
+			PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+		"method": schema.StringAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
+		},
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
+		},
+		"project_id": schema.StringAttribute{
+			Optional:      true,
+			Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+		},
+		"credentials": schema.SingleNestedAttribute{
+			Required:    true,
+			Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
+			Attributes:  r.CredentialsAttributes,
+		},
+		"credentials_hash": schema.StringAttribute{
+			Computed:    true,
+			Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
+		},
+	}
+
+	if r.SupportsGateway {
+		attributes["gateway_id"] = schema.StringAttribute{
+			Optional:    true,
+			Description: "The Gateway ID to use for the app connection. If not specified, the Internet Gateway will be used.",
+		}
+	}
+
 	resp.Schema = schema.Schema{
 		Description: fmt.Sprintf("Create and manage %s App Connection", r.AppConnectionName),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Description:   "The ID of the app connection",
-				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
-			},
-			"method": schema.StringAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The method used to authenticate with %s. Possible values are: %s", r.AppConnectionName, strings.Join(r.AllowedMethods, ", ")),
-			},
-			"name": schema.StringAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The name of the %s App Connection to create. Must be slug-friendly", r.AppConnectionName),
-			},
-			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: fmt.Sprintf("An optional description for the %s App Connection.", r.AppConnectionName),
-			},
-			"project_id": schema.StringAttribute{
-				Optional:      true,
-				Description:   "The ID of the project to scope the app connection to. If not provided, the app connection will be scoped to the organization.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-			},
-			"credentials": schema.SingleNestedAttribute{
-				Required:    true,
-				Description: fmt.Sprintf("The credentials for the %s App Connection", r.AppConnectionName),
-				Attributes:  r.CredentialsAttributes,
-			},
-			"credentials_hash": schema.StringAttribute{
-				Computed:    true,
-				Description: fmt.Sprintf("The hash of the %s App Connection credentials", r.AppConnectionName),
-			},
-		},
+		Attributes:  attributes,
 	}
 }
 
@@ -173,8 +252,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Retrieve values from plan
-	var plan AppConnectionBaseResourceModel
-	diags := req.Plan.Get(ctx, &plan)
+	plan, gatewayId, diags := r.readModel(ctx, req.Plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -212,6 +290,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
+			GatewayId:   r.gatewayIdForRequest(gatewayId),
 		})
 		return apiErr
 	})
@@ -227,7 +306,7 @@ func (r *AppConnectionBaseResource) Create(ctx context.Context, req resource.Cre
 	plan.ID = types.StringValue(appConnection.Id)
 	plan.CredentialsHash = types.StringValue(appConnection.CredentialsHash)
 
-	diags = resp.State.Set(ctx, plan)
+	diags = resp.State.Set(ctx, r.stateValue(plan, gatewayId))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -245,8 +324,7 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	// Get current state
-	var state AppConnectionBaseResourceModel
-	diags := req.State.Get(ctx, &state)
+	state, gatewayId, diags := r.readModel(ctx, req.State)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -270,6 +348,9 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 		}
 	}
 
+	// Reconcile gateway_id from the API so out-of-band changes are detected as drift.
+	gatewayId = r.reconcileGatewayId(gatewayId, appConnection)
+
 	if state.CredentialsHash.ValueString() != appConnection.CredentialsHash {
 		resp.Diagnostics.AddWarning(
 			"App connection credentials conflict",
@@ -283,7 +364,7 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 			return
 		}
 
-		diags = resp.State.Set(ctx, state)
+		diags = resp.State.Set(ctx, r.stateValue(state, gatewayId))
 		resp.Diagnostics.Append(diags...)
 		return
 	}
@@ -301,7 +382,7 @@ func (r *AppConnectionBaseResource) Read(ctx context.Context, req resource.ReadR
 	state.Method = types.StringValue(appConnection.Method)
 	state.Name = types.StringValue(appConnection.Name)
 
-	diags = resp.State.Set(ctx, state)
+	diags = resp.State.Set(ctx, r.stateValue(state, gatewayId))
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -315,15 +396,13 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	// Retrieve values from plan
-	var plan AppConnectionBaseResourceModel
-	diags := req.Plan.Get(ctx, &plan)
+	plan, gatewayId, diags := r.readModel(ctx, req.Plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	var state AppConnectionBaseResourceModel
-	diags = req.State.Get(ctx, &state)
+	state, _, diags := r.readModel(ctx, req.State)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -362,6 +441,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 			Method:      plan.Method.ValueString(),
 			Credentials: credentialsMap,
 			ProjectId:   plan.ProjectId.ValueString(),
+			GatewayId:   r.gatewayIdForRequest(gatewayId),
 		})
 		return apiErr
 	})
@@ -376,7 +456,7 @@ func (r *AppConnectionBaseResource) Update(ctx context.Context, req resource.Upd
 
 	plan.CredentialsHash = types.StringValue(appConnection.CredentialsHash)
 
-	diags = resp.State.Set(ctx, plan)
+	diags = resp.State.Set(ctx, r.stateValue(plan, gatewayId))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -392,8 +472,7 @@ func (r *AppConnectionBaseResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	var state AppConnectionBaseResourceModel
-	diags := req.State.Get(ctx, &state)
+	state, _, diags := r.readModel(ctx, req.State)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
This changes the base app connection file to allow the creation of app connections. There is a lot of structural changes because not all app connections support gateways, so it doesn't make sense for use to allow this in all app connections inside terraform. For now, this will be by resource, so every time we need an app connection with gateway we can update the provider. 

Test: 
- start a vault instance locally 
- try to create an app connection using the resource.tf example from the vault app connection 
- First create it without gateway 
- Update it (add the gateway)
- remove the gateway 
- Make sure that the changes are being reflected inside infisical. 