### PR TITLE
fix: prevent `last_updated` to trigger a diff in `apply`

### DIFF
--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -92,7 +92,7 @@ ephemeral "infisical_secret" "ephemeral-secret" {
 
 - `metadata` (Map of String) Metadata associated with the secret as key-value pairs.
 - `secret_reminder` (Attributes) (see [below for nested schema](#nestedatt--secret_reminder))
-- `tag_ids` (List of String) Tag ids to be attached for the secrets.
+- `tag_ids` (Set of String) Tag ids to be attached for the secrets.
 - `value` (String, Sensitive) The value of the secret in plain text. This is required if `value_wo` is not set.
 - `value_wo` (String) The value of the secret in plain text as a write-only secret. If set, the secret value will not be stored in state. This is required if `value` is not set. Requires Terraform version 1.11.0 or higher.
 - `value_wo_version` (Number) Used together with value_wo to trigger an update. Increment this value when an update to the value_wo is required.
@@ -101,7 +101,7 @@ ephemeral "infisical_secret" "ephemeral-secret" {
 ### Read-Only
 
 - `id` (String) The ID of the secret
-- `last_updated` (String)
+- `last_updated` (String) The last time the secret was updated.
 
 <a id="nestedatt--secret_reminder"></a>
 ### Nested Schema for `secret_reminder`

--- a/internal/provider/resource/secret_resource.go
+++ b/internal/provider/resource/secret_resource.go
@@ -184,8 +184,9 @@ func (r *secretResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 
 			"last_updated": schema.StringAttribute{
-				Description: "The last time the secret was updated.",
-				Computed:    true,
+				Description:   "The last time the secret was updated.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"tag_ids": schema.SetAttribute{
 				ElementType: types.StringType,


### PR DESCRIPTION
## Context

After #279 was merged, two consecutive `apply` calls would generate a diff on `last_updated_at`. This fixes this issue

## How to test it

1. Apply a secret
2. Try applying again without any changes, it should say there's no changes