### PR TITLE
feat(datasource): handle 404 for datasource infisical_projects

### DIFF
--- a/internal/provider/datasource/projects_data_source.go
+++ b/internal/provider/datasource/projects_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -172,6 +173,9 @@ func (d *ProjectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 	})
 	if err != nil {
 		if errors.Is(err, infisical.ErrNotFound) {
+			tflog.Debug(ctx, "Project not found", map[string]interface{}{
+				"slug": data.Slug.ValueString(),
+			})
 			data.Environments = make(map[string]ProjectEnvironmentDetails)
 			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 			return

--- a/internal/provider/datasource/projects_data_source.go
+++ b/internal/provider/datasource/projects_data_source.go
@@ -2,6 +2,7 @@ package datasource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -170,11 +171,17 @@ func (d *ProjectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		Slug: data.Slug.ValueString(),
 	})
 	if err != nil {
+		if errors.Is(err, infisical.ErrNotFound) {
+			data.Environments = make(map[string]ProjectEnvironmentDetails)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Something went wrong while fetching the project",
 			"If the error is not clear, please get in touch at infisical.com/slack\n\n"+
 				"Infisical Client Error: "+err.Error(),
 		)
+		return
 	}
 
 	data = ProjectDataSourceModel{


### PR DESCRIPTION
## Problem
The `infisical_projects` data source currently fails the entire plan/apply with an error diagnostic when the requested project slug does not exist yet. This makes it impossible to use the data source for existence checks. Existence checks can be used for writing idempotent Terraform configurations that need to conditionally import or create a resource.
Additionally, the `Read` function is missing a `return` after `AddError`, allowing execution to fall through and populate state with zero values even when an error had occurred.

## Changes
- `internal/provider/datasource/projects_data_source.go`
  - On HTTP 404 (`ErrNotFound`): initialize an empty `Environments` map, write the zero-value state (all computed attributes remain null/empty), and return without an error diagnostic. This allows plan/apply to continue.
  - Add missing return after `AddError` for non-404 errors, preventing fall-through.

## Use case
This enables conditional import patterns in HCL:
```hcl
data "infisical_projects" "existing" {
  slug = local.project_name
}

import {
  for_each = data.infisical_projects.existing.id != null ? { "this" = data.infisical_projects.existing.id } : {}
  to       = infisical_project.this
  id       = each.value
}
```

Without this change, the data source would fail on first apply (before the project exists), making stateless workflows / conditional imports impossible.