### PR TITLE
feat(resource): add import for project user

### DIFF
--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -92,3 +92,11 @@ Read-Only:
 - `first_name` (String) The first name of the user
 - `id` (String) The id of the user
 - `last_name` (String) The last name of the user
+
+## Import
+
+Import using `<project_id>,<username>`:
+
+```shell
+terraform import infisical_project_user.example <project-id>,<username-or-email>
+```

--- a/docs/resources/project_user.md
+++ b/docs/resources/project_user.md
@@ -95,7 +95,7 @@ Read-Only:
 
 ## Import
 
-Import using `<project_id>,<username>`:
+Import using `<project_id>,<username-or-email>`:
 
 ```shell
 terraform import infisical_project_user.example <project-id>,<username-or-email>

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -651,11 +651,19 @@ func (r *ProjectUserResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 func (r *ProjectUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if !r.client.Config.IsMachineIdentityAuth {
+		resp.Diagnostics.AddError(
+			"Unable to import project user",
+			"Only Machine Identity authentication is supported for this operation",
+		)
+		return
+	}
+
 	parts := strings.SplitN(req.ID, ",", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Invalid import ID",
-			"Expected format: <project_id>,<username>",
+			"Expected format: <project_id>,<username-or-email>",
 		)
 		return
 	}

--- a/internal/provider/resource/project_user_resource.go
+++ b/internal/provider/resource/project_user_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	infisical "terraform-provider-infisical/internal/client"
 	"time"
 
@@ -18,7 +19,8 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource = &ProjectUserResource{}
+	_ resource.Resource                = &ProjectUserResource{}
+	_ resource.ResourceWithImportState = &ProjectUserResource{}
 )
 
 // NewProjectResource is a helper function to simplify the provider implementation.
@@ -646,4 +648,34 @@ func (r *ProjectUserResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+}
+
+func (r *ProjectUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, ",", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			"Expected format: <project_id>,<username>",
+		)
+		return
+	}
+
+	projectID := parts[0]
+	username := parts[1]
+
+	projectUserDetails, err := r.client.GetProjectUserByUsername(infisical.GetProjectUserByUserNameRequest{
+		ProjectID: projectID,
+		Username:  username,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error fetching project user",
+			"Couldn't find user in project, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("username"), username)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("membership_id"), projectUserDetails.Membership.ID)...)
 }


### PR DESCRIPTION
Implement import functionality for infisical_project_user resources.

## Changes
- Add `ImportState` method with composite key format: `<project_id>,<username>`
- Validate Machine Identity authentication requirement
- Add import example and regenerated documentation

(I closely followed the implementation of #251 here)

## Example Usage
```
terraform import infisical_project_user.example my-project,my-user
```