### PR TITLE
feat(project_group): support custom role slugs in project group resource

### DIFF
--- a/crossplane/project_group_resource/project_group.go
+++ b/crossplane/project_group_resource/project_group.go
@@ -243,6 +243,10 @@ func (r *ProjectGroupResource) Read(ctx context.Context, req resource.ReadReques
 			RoleSlug: el.Role,
 		}
 
+		if el.Role == "custom" && el.CustomRoleSlug != "" {
+			val.RoleSlug = el.CustomRoleSlug
+		}
+
 		planRoles = append(planRoles, val)
 	}
 


### PR DESCRIPTION
## Summary

Fixes incorrect role mapping in the Crossplane `project_group` resource **Read** handler when Infisical returns custom roles. The API sets `role` to `"custom"` and puts the actual slug in `customRoleSlug`; this change maps `RoleSlug` from `CustomRoleSlug` in that case, matching the Terraform provider behavior in `internal/provider/resource/project_group.go`.

## Problem

Without this fix, Read persisted `"custom"` as the role slug instead of the real custom role slug, causing perpetual drift on subsequent applies.