### PR TITLE
feat: add basic_constraints and extra subject types

### DIFF
--- a/docs/resources/cert_manager_certificate_policy.md
+++ b/docs/resources/cert_manager_certificate_policy.md
@@ -194,7 +194,7 @@ resource "infisical_cert_manager_certificate_policy" "code_signing" {
 - `extended_key_usages` (Block, Optional) Extended key usage policies for the certificate policy (see [below for nested schema](#nestedblock--extended_key_usages))
 - `key_usages` (Block, Optional) Key usage policies for the certificate policy (see [below for nested schema](#nestedblock--key_usages))
 - `sans` (Block List) Subject alternative name (SAN) policies for the certificate policy (see [below for nested schema](#nestedblock--sans))
-- `subject` (Block List) Subject attribute policies for the certificate policy. Each block constrains a single subject DN attribute (e.g. common_name, organization). Values are matched against the corresponding attribute parsed from the CSR; the '*' wildcard matches any sequence of characters (including dots). (see [below for nested schema](#nestedblock--subject))
+- `subject` (Block List) Subject attribute policies for the certificate policy. Each block constrains a single subject DN attribute (e.g. common_name, organization). Values are matched against the corresponding attribute parsed from the CSR; the '*' wildcard matches any sequence of characters (including dots). For common_name, matching uses the CN attribute only, so domainComponent (DC) attributes are ignored. (see [below for nested schema](#nestedblock--subject))
 - `validity` (Block, Optional) Validity constraints for the certificate policy (see [below for nested schema](#nestedblock--validity))
 
 ### Read-Only

--- a/docs/resources/cert_manager_certificate_policy.md
+++ b/docs/resources/cert_manager_certificate_policy.md
@@ -79,6 +79,65 @@ resource "infisical_cert_manager_certificate_policy" "web_server" {
     signature     = ["SHA256-RSA", "SHA256-ECDSA", "SHA384-ECDSA"]
     key_algorithm = ["RSA-2048", "RSA-3072", "ECDSA-P256", "ECDSA-P384"]
   }
+
+  # Leaf certificates must not be CA certificates
+  basic_constraints {
+    is_ca = "denied"
+  }
+}
+
+resource "infisical_cert_manager_certificate_policy" "intermediate_ca" {
+  name        = "intermediate-ca-policy"
+  description = "Policy for intermediate CA certificates"
+
+  subject {
+    type     = "common_name"
+    required = ["Example Corp Intermediate CA"]
+  }
+
+  subject {
+    type     = "organization"
+    required = ["Example Corp"]
+  }
+
+  subject {
+    type    = "organizational_unit"
+    allowed = ["PKI", "Security"]
+  }
+
+  subject {
+    type     = "country"
+    required = ["US"]
+  }
+
+  subject {
+    type    = "state"
+    allowed = ["California"]
+  }
+
+  subject {
+    type    = "locality"
+    allowed = ["San Francisco"]
+  }
+
+  key_usages {
+    required = ["key_cert_sign", "crl_sign"]
+  }
+
+  validity {
+    max = "5y"
+  }
+
+  algorithms {
+    signature     = ["SHA256-RSA", "SHA384-ECDSA"]
+    key_algorithm = ["RSA-4096", "ECDSA-P384"]
+  }
+
+  # Issued certificates must be CA certificates, limited to one further level of subordinate CAs
+  basic_constraints {
+    is_ca           = "required"
+    max_path_length = 1
+  }
 }
 
 resource "infisical_cert_manager_certificate_policy" "code_signing" {
@@ -130,11 +189,12 @@ resource "infisical_cert_manager_certificate_policy" "code_signing" {
 ### Optional
 
 - `algorithms` (Block, Optional) Algorithm constraints for the certificate policy. At least one signature algorithm and one key algorithm must be specified. (see [below for nested schema](#nestedblock--algorithms))
+- `basic_constraints` (Block, Optional) Basic constraints policy for the certificate policy, controlling whether issued certificates may act as certificate authorities. (see [below for nested schema](#nestedblock--basic_constraints))
 - `description` (String) The description of the certificate policy
 - `extended_key_usages` (Block, Optional) Extended key usage policies for the certificate policy (see [below for nested schema](#nestedblock--extended_key_usages))
 - `key_usages` (Block, Optional) Key usage policies for the certificate policy (see [below for nested schema](#nestedblock--key_usages))
 - `sans` (Block List) Subject alternative name (SAN) policies for the certificate policy (see [below for nested schema](#nestedblock--sans))
-- `subject` (Block List) Subject attribute policies for the certificate policy (see [below for nested schema](#nestedblock--subject))
+- `subject` (Block List) Subject attribute policies for the certificate policy. Each block constrains a single subject DN attribute (e.g. common_name, organization). Values are matched against the corresponding attribute parsed from the CSR; the '*' wildcard matches any sequence of characters (including dots). (see [below for nested schema](#nestedblock--subject))
 - `validity` (Block, Optional) Validity constraints for the certificate policy (see [below for nested schema](#nestedblock--validity))
 
 ### Read-Only
@@ -148,6 +208,15 @@ Required:
 
 - `key_algorithm` (List of String) List of allowed key algorithms (at least one required). Supported values: RSA-2048, RSA-3072, RSA-4096, ECDSA-P256, ECDSA-P521, ECDSA-P384
 - `signature` (List of String) List of allowed signature algorithms (at least one required). Supported values: SHA256-RSA, SHA512-RSA, SHA384-ECDSA, SHA384-RSA, SHA256-ECDSA, SHA512-ECDSA
+
+
+<a id="nestedblock--basic_constraints"></a>
+### Nested Schema for `basic_constraints`
+
+Optional:
+
+- `is_ca` (String) Policy for the CA flag (basic constraints CA:TRUE) on issued certificates. Possible values: allowed, required, denied
+- `max_path_length` (Number) Maximum path length constraint for CA certificates. Use -1 for unlimited, or a non-negative integer to cap how many intermediate CAs may appear below a certificate issued under this policy. Only applies when is_ca is allowed or required; it is ignored when is_ca is denied.
 
 
 <a id="nestedblock--extended_key_usages"></a>
@@ -189,13 +258,13 @@ Optional:
 
 Required:
 
-- `type` (String) The subject attribute type. Possible values: common_name, organization, country
+- `type` (String) The subject attribute type. Possible values: common_name, organization, organizational_unit, country, state, locality
 
 Optional:
 
-- `allowed` (List of String) List of allowed values for this subject attribute
-- `denied` (List of String) List of denied values for this subject attribute
-- `required` (List of String) List of required values for this subject attribute
+- `allowed` (List of String) List of allowed values for this subject attribute. Supports the '*' wildcard.
+- `denied` (List of String) List of denied values for this subject attribute. Supports the '*' wildcard.
+- `required` (List of String) List of required values for this subject attribute. Supports the '*' wildcard.
 
 
 <a id="nestedblock--validity"></a>

--- a/examples/resources/infisical_cert_manager_certificate_policy/resource.tf
+++ b/examples/resources/infisical_cert_manager_certificate_policy/resource.tf
@@ -64,6 +64,65 @@ resource "infisical_cert_manager_certificate_policy" "web_server" {
     signature     = ["SHA256-RSA", "SHA256-ECDSA", "SHA384-ECDSA"]
     key_algorithm = ["RSA-2048", "RSA-3072", "ECDSA-P256", "ECDSA-P384"]
   }
+
+  # Leaf certificates must not be CA certificates
+  basic_constraints {
+    is_ca = "denied"
+  }
+}
+
+resource "infisical_cert_manager_certificate_policy" "intermediate_ca" {
+  name        = "intermediate-ca-policy"
+  description = "Policy for intermediate CA certificates"
+
+  subject {
+    type     = "common_name"
+    required = ["Example Corp Intermediate CA"]
+  }
+
+  subject {
+    type     = "organization"
+    required = ["Example Corp"]
+  }
+
+  subject {
+    type    = "organizational_unit"
+    allowed = ["PKI", "Security"]
+  }
+
+  subject {
+    type     = "country"
+    required = ["US"]
+  }
+
+  subject {
+    type    = "state"
+    allowed = ["California"]
+  }
+
+  subject {
+    type    = "locality"
+    allowed = ["San Francisco"]
+  }
+
+  key_usages {
+    required = ["key_cert_sign", "crl_sign"]
+  }
+
+  validity {
+    max = "5y"
+  }
+
+  algorithms {
+    signature     = ["SHA256-RSA", "SHA384-ECDSA"]
+    key_algorithm = ["RSA-4096", "ECDSA-P384"]
+  }
+
+  # Issued certificates must be CA certificates, limited to one further level of subordinate CAs
+  basic_constraints {
+    is_ca           = "required"
+    max_path_length = 1
+  }
 }
 
 resource "infisical_cert_manager_certificate_policy" "code_signing" {

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -3052,6 +3052,11 @@ type CertificatePolicyValidity struct {
 	Max string `json:"max,omitempty"`
 }
 
+type CertificatePolicyBasicConstraints struct {
+	IsCA          string `json:"isCA,omitempty"`
+	MaxPathLength *int64 `json:"maxPathLength,omitempty"`
+}
+
 type CertificatePolicy struct {
 	Id                string                              `json:"id"`
 	ProjectId         string                              `json:"projectId"`
@@ -3063,6 +3068,7 @@ type CertificatePolicy struct {
 	ExtendedKeyUsages *CertificatePolicyExtendedKeyUsages `json:"extendedKeyUsages,omitempty"`
 	Algorithms        *CertificatePolicyAlgorithms        `json:"algorithms,omitempty"`
 	Validity          *CertificatePolicyValidity          `json:"validity,omitempty"`
+	BasicConstraints  *CertificatePolicyBasicConstraints  `json:"basicConstraints,omitempty"`
 	CreatedAt         string                              `json:"createdAt"`
 	UpdatedAt         string                              `json:"updatedAt"`
 }
@@ -3076,6 +3082,7 @@ type CreateCertificatePolicyRequest struct {
 	ExtendedKeyUsages *CertificatePolicyExtendedKeyUsages `json:"extendedKeyUsages,omitempty"`
 	Algorithms        *CertificatePolicyAlgorithms        `json:"algorithms,omitempty"`
 	Validity          *CertificatePolicyValidity          `json:"validity,omitempty"`
+	BasicConstraints  *CertificatePolicyBasicConstraints  `json:"basicConstraints,omitempty"`
 }
 
 type CreateCertificatePolicyResponse struct {
@@ -3100,6 +3107,7 @@ type UpdateCertificatePolicyRequest struct {
 	ExtendedKeyUsages *CertificatePolicyExtendedKeyUsages `json:"extendedKeyUsages,omitempty"`
 	Algorithms        *CertificatePolicyAlgorithms        `json:"algorithms,omitempty"`
 	Validity          *CertificatePolicyValidity          `json:"validity,omitempty"`
+	BasicConstraints  *CertificatePolicyBasicConstraints  `json:"basicConstraints,omitempty"`
 }
 
 type UpdateCertificatePolicyResponse struct {

--- a/internal/provider/resource/cert_manager_certificate_policy.go
+++ b/internal/provider/resource/cert_manager_certificate_policy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	infisical "terraform-provider-infisical/internal/client"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,8 +19,9 @@ import (
 )
 
 var (
-	SUPPORTED_SUBJECT_TYPES   = []string{"common_name", "organization", "country"}
+	SUPPORTED_SUBJECT_TYPES   = []string{"common_name", "organization", "organizational_unit", "country", "state", "locality"}
 	SUPPORTED_SAN_TYPES       = []string{"dns_name", "ip_address", "email", "uri"}
+	SUPPORTED_POLICY_STATES   = []string{"allowed", "required", "denied"}
 	SUPPORTED_CERT_KEY_USAGES = []string{
 		"digital_signature", "key_encipherment", "non_repudiation",
 		"data_encipherment", "key_agreement", "key_cert_sign",
@@ -86,6 +88,11 @@ type certManagerCertificatePolicyValidityModel struct {
 	Max types.String `tfsdk:"max"`
 }
 
+type certManagerCertificatePolicyBasicConstraintsModel struct {
+	IsCa          types.String `tfsdk:"is_ca"`
+	MaxPathLength types.Int64  `tfsdk:"max_path_length"`
+}
+
 type certManagerCertificatePolicyResourceModel struct {
 	Id                types.String                                        `tfsdk:"id"`
 	Name              types.String                                        `tfsdk:"name"`
@@ -96,6 +103,7 @@ type certManagerCertificatePolicyResourceModel struct {
 	ExtendedKeyUsages *certManagerCertificatePolicyExtendedKeyUsagesModel `tfsdk:"extended_key_usages"`
 	Algorithms        *certManagerCertificatePolicyAlgorithmsModel        `tfsdk:"algorithms"`
 	Validity          *certManagerCertificatePolicyValidityModel          `tfsdk:"validity"`
+	BasicConstraints  *certManagerCertificatePolicyBasicConstraintsModel  `tfsdk:"basic_constraints"`
 }
 
 func (r *certManagerCertificatePolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -124,7 +132,7 @@ func (r *certManagerCertificatePolicyResource) Schema(_ context.Context, _ resou
 		},
 		Blocks: map[string]schema.Block{
 			"subject": schema.ListNestedBlock{
-				Description: "Subject attribute policies for the certificate policy",
+				Description: "Subject attribute policies for the certificate policy. Each block constrains a single subject DN attribute (e.g. common_name, organization). Values are matched against the corresponding attribute parsed from the CSR; the '*' wildcard matches any sequence of characters (including dots). For common_name, matching uses the CN attribute only, so domainComponent (DC) attributes are ignored.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
@@ -135,17 +143,17 @@ func (r *certManagerCertificatePolicyResource) Schema(_ context.Context, _ resou
 							},
 						},
 						"allowed": schema.ListAttribute{
-							Description: "List of allowed values for this subject attribute",
+							Description: "List of allowed values for this subject attribute. Supports the '*' wildcard.",
 							Optional:    true,
 							ElementType: types.StringType,
 						},
 						"required": schema.ListAttribute{
-							Description: "List of required values for this subject attribute",
+							Description: "List of required values for this subject attribute. Supports the '*' wildcard.",
 							Optional:    true,
 							ElementType: types.StringType,
 						},
 						"denied": schema.ListAttribute{
-							Description: "List of denied values for this subject attribute",
+							Description: "List of denied values for this subject attribute. Supports the '*' wildcard.",
 							Optional:    true,
 							ElementType: types.StringType,
 						},
@@ -268,6 +276,25 @@ func (r *certManagerCertificatePolicyResource) Schema(_ context.Context, _ resou
 					"max": schema.StringAttribute{
 						Description: "Maximum validity period (e.g., '90d', '2y', '6m')",
 						Optional:    true,
+					},
+				},
+			},
+			"basic_constraints": schema.SingleNestedBlock{
+				Description: "Basic constraints policy for the certificate policy, controlling whether issued certificates may act as certificate authorities.",
+				Attributes: map[string]schema.Attribute{
+					"is_ca": schema.StringAttribute{
+						Description: "Policy for the CA flag (basic constraints CA:TRUE) on issued certificates. Possible values: " + strings.Join(SUPPORTED_POLICY_STATES, ", "),
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf(SUPPORTED_POLICY_STATES...),
+						},
+					},
+					"max_path_length": schema.Int64Attribute{
+						Description: "Maximum path length constraint for CA certificates. Use -1 for unlimited, or a non-negative integer to cap how many intermediate CAs may appear below a certificate issued under this policy. Only applies when is_ca is allowed or required; it is ignored when is_ca is denied.",
+						Optional:    true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(-1),
+						},
 					},
 				},
 			},
@@ -430,6 +457,19 @@ func (r *certManagerCertificatePolicyResource) Create(ctx context.Context, req r
 	if plan.Validity != nil && !plan.Validity.Max.IsNull() {
 		createPolicyRequest.Validity = &infisical.CertificatePolicyValidity{
 			Max: plan.Validity.Max.ValueString(),
+		}
+	}
+
+	if plan.BasicConstraints != nil {
+		createPolicyRequest.BasicConstraints = &infisical.CertificatePolicyBasicConstraints{}
+
+		if !plan.BasicConstraints.IsCa.IsNull() {
+			createPolicyRequest.BasicConstraints.IsCA = plan.BasicConstraints.IsCa.ValueString()
+		}
+
+		if !plan.BasicConstraints.MaxPathLength.IsNull() {
+			maxPathLength := plan.BasicConstraints.MaxPathLength.ValueInt64()
+			createPolicyRequest.BasicConstraints.MaxPathLength = &maxPathLength
 		}
 	}
 
@@ -638,6 +678,22 @@ func (r *certManagerCertificatePolicyResource) Read(ctx context.Context, req res
 		}
 	}
 
+	if policy.CertificatePolicy.BasicConstraints != nil {
+		state.BasicConstraints = &certManagerCertificatePolicyBasicConstraintsModel{}
+
+		if policy.CertificatePolicy.BasicConstraints.IsCA != "" {
+			state.BasicConstraints.IsCa = types.StringValue(policy.CertificatePolicy.BasicConstraints.IsCA)
+		} else {
+			state.BasicConstraints.IsCa = types.StringNull()
+		}
+
+		if policy.CertificatePolicy.BasicConstraints.MaxPathLength != nil {
+			state.BasicConstraints.MaxPathLength = types.Int64Value(*policy.CertificatePolicy.BasicConstraints.MaxPathLength)
+		} else {
+			state.BasicConstraints.MaxPathLength = types.Int64Null()
+		}
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -780,6 +836,19 @@ func (r *certManagerCertificatePolicyResource) Update(ctx context.Context, req r
 	if plan.Validity != nil && !plan.Validity.Max.IsNull() {
 		updatePolicyRequest.Validity = &infisical.CertificatePolicyValidity{
 			Max: plan.Validity.Max.ValueString(),
+		}
+	}
+
+	if plan.BasicConstraints != nil {
+		updatePolicyRequest.BasicConstraints = &infisical.CertificatePolicyBasicConstraints{}
+
+		if !plan.BasicConstraints.IsCa.IsNull() {
+			updatePolicyRequest.BasicConstraints.IsCA = plan.BasicConstraints.IsCa.ValueString()
+		}
+
+		if !plan.BasicConstraints.MaxPathLength.IsNull() {
+			maxPathLength := plan.BasicConstraints.MaxPathLength.ValueInt64()
+			updatePolicyRequest.BasicConstraints.MaxPathLength = &maxPathLength
 		}
 	}
 

--- a/internal/provider/resource/cert_manager_certificate_policy.go
+++ b/internal/provider/resource/cert_manager_certificate_policy.go
@@ -42,7 +42,8 @@ var (
 )
 
 var (
-	_ resource.Resource = &certManagerCertificatePolicyResource{}
+	_ resource.Resource                   = &certManagerCertificatePolicyResource{}
+	_ resource.ResourceWithValidateConfig = &certManagerCertificatePolicyResource{}
 )
 
 func NewCertManagerCertificatePolicyResource() resource.Resource {
@@ -108,6 +109,25 @@ type certManagerCertificatePolicyResourceModel struct {
 
 func (r *certManagerCertificatePolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_cert_manager_certificate_policy"
+}
+
+func (r *certManagerCertificatePolicyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config certManagerCertificatePolicyResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.BasicConstraints != nil &&
+		config.BasicConstraints.IsCa.ValueString() == "denied" &&
+		!config.BasicConstraints.MaxPathLength.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("basic_constraints").AtName("max_path_length"),
+			"Invalid basic_constraints configuration",
+			"max_path_length cannot be set when is_ca is \"denied\". Remove max_path_length or set is_ca to \"allowed\" or \"required\".",
+		)
+	}
 }
 
 func (r *certManagerCertificatePolicyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -460,7 +480,7 @@ func (r *certManagerCertificatePolicyResource) Create(ctx context.Context, req r
 		}
 	}
 
-	if plan.BasicConstraints != nil {
+	if plan.BasicConstraints != nil && (!plan.BasicConstraints.IsCa.IsNull() || !plan.BasicConstraints.MaxPathLength.IsNull()) {
 		createPolicyRequest.BasicConstraints = &infisical.CertificatePolicyBasicConstraints{}
 
 		if !plan.BasicConstraints.IsCa.IsNull() {
@@ -839,7 +859,7 @@ func (r *certManagerCertificatePolicyResource) Update(ctx context.Context, req r
 		}
 	}
 
-	if plan.BasicConstraints != nil {
+	if plan.BasicConstraints != nil && (!plan.BasicConstraints.IsCa.IsNull() || !plan.BasicConstraints.MaxPathLength.IsNull()) {
 		updatePolicyRequest.BasicConstraints = &infisical.CertificatePolicyBasicConstraints{}
 
 		if !plan.BasicConstraints.IsCa.IsNull() {


### PR DESCRIPTION
Extends the certificate policy resource so it covers the newer policy options the backend already supports: control over whether issued certificates can act as certificate authorities, more subject fields (org unit, state, locality), and clearer docs on how values are matched.