### PR TITLE
fix(auth): access token max ttl ca cert newline

### DIFF
--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1590,9 +1590,9 @@ type CreateIdentityAwsAuthRequest struct {
 	AllowedPrincipalArns    string                         `json:"allowedPrincipalArns,omitempty"`
 	AllowedAccountIDS       string                         `json:"allowedAccountIds,omitempty"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
-	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`
-	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL,omitempty"`
-	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit,omitempty"`
+	AccessTokenTTL          *int64                         `json:"accessTokenTTL,omitempty"`
+	AccessTokenMaxTTL       *int64                         `json:"accessTokenMaxTTL,omitempty"`
+	AccessTokenNumUsesLimit *int64                         `json:"accessTokenNumUsesLimit,omitempty"`
 }
 
 type CreateIdentityAwsAuthResponse struct {
@@ -1605,9 +1605,9 @@ type UpdateIdentityAwsAuthRequest struct {
 	AllowedPrincipalArns    string                         `json:"allowedPrincipalArns,omitempty"`
 	AllowedAccountIDS       string                         `json:"allowedAccountIds,omitempty"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
-	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`
-	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL,omitempty"`
-	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit,omitempty"`
+	AccessTokenTTL          *int64                         `json:"accessTokenTTL,omitempty"`
+	AccessTokenMaxTTL       *int64                         `json:"accessTokenMaxTTL,omitempty"`
+	AccessTokenNumUsesLimit *int64                         `json:"accessTokenNumUsesLimit,omitempty"`
 }
 
 type UpdateIdentityAwsAuthResponse struct {

--- a/internal/client/model.go
+++ b/internal/client/model.go
@@ -1590,9 +1590,9 @@ type CreateIdentityAwsAuthRequest struct {
 	AllowedPrincipalArns    string                         `json:"allowedPrincipalArns,omitempty"`
 	AllowedAccountIDS       string                         `json:"allowedAccountIds,omitempty"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
-	AccessTokenTTL          int64                          `json:"accessTokenTTL"`
-	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL"`
-	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit"`
+	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`
+	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL,omitempty"`
+	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit,omitempty"`
 }
 
 type CreateIdentityAwsAuthResponse struct {
@@ -1605,9 +1605,9 @@ type UpdateIdentityAwsAuthRequest struct {
 	AllowedPrincipalArns    string                         `json:"allowedPrincipalArns,omitempty"`
 	AllowedAccountIDS       string                         `json:"allowedAccountIds,omitempty"`
 	AccessTokenTrustedIPS   []IdentityAuthTrustedIpRequest `json:"accessTokenTrustedIps,omitempty"`
-	AccessTokenTTL          int64                          `json:"accessTokenTTL"`
-	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL"`
-	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit"`
+	AccessTokenTTL          int64                          `json:"accessTokenTTL,omitempty"`
+	AccessTokenMaxTTL       int64                          `json:"accessTokenMaxTTL,omitempty"`
+	AccessTokenNumUsesLimit int64                          `json:"accessTokenNumUsesLimit,omitempty"`
 }
 
 type UpdateIdentityAwsAuthResponse struct {

--- a/internal/pkg/customtypes/trimmed_string.go
+++ b/internal/pkg/customtypes/trimmed_string.go
@@ -1,0 +1,116 @@
+// Package customtypes contains custom terraform-plugin-framework attribute
+// types used across the provider.
+package customtypes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TrimmedStringType is a string type whose values are considered semantically
+// equal when they match after trimming leading/trailing whitespace.
+//
+// This is intended for attributes whose backing API normalizes the stored value
+// by trimming whitespace (e.g. a PEM certificate). Without semantic equality,
+// supplying a value with a trailing newline causes Terraform to report a
+// "Provider produced inconsistent result after apply" error and a perpetual
+// diff, because the value returned by the API differs from the configured value.
+type TrimmedStringType struct {
+	basetypes.StringType
+}
+
+var _ basetypes.StringTypable = TrimmedStringType{}
+
+func (t TrimmedStringType) Equal(o attr.Type) bool {
+	other, ok := o.(TrimmedStringType)
+	if !ok {
+		return false
+	}
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t TrimmedStringType) String() string {
+	return "customtypes.TrimmedStringType"
+}
+
+func (t TrimmedStringType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return TrimmedStringValue{StringValue: in}, nil
+}
+
+func (t TrimmedStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t TrimmedStringType) ValueType(_ context.Context) attr.Value {
+	return TrimmedStringValue{}
+}
+
+// TrimmedStringValue is the value type produced by TrimmedStringType.
+type TrimmedStringValue struct {
+	basetypes.StringValue
+}
+
+var (
+	_ basetypes.StringValuable                   = TrimmedStringValue{}
+	_ basetypes.StringValuableWithSemanticEquals = TrimmedStringValue{}
+)
+
+// NewTrimmedStringValue returns a known TrimmedStringValue for the given string.
+func NewTrimmedStringValue(value string) TrimmedStringValue {
+	return TrimmedStringValue{StringValue: basetypes.NewStringValue(value)}
+}
+
+func (v TrimmedStringValue) Type(_ context.Context) attr.Type {
+	return TrimmedStringType{}
+}
+
+func (v TrimmedStringValue) Equal(o attr.Value) bool {
+	other, ok := o.(TrimmedStringValue)
+	if !ok {
+		return false
+	}
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// StringSemanticEquals treats two values as equal when they are identical after
+// trimming surrounding whitespace.
+func (v TrimmedStringValue) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(TrimmedStringValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			fmt.Sprintf("expected value type %T but got %T", v, newValuable),
+		)
+		return false, diags
+	}
+
+	// Only compare when both sides are known; null/unknown are handled by the framework.
+	if v.IsNull() || v.IsUnknown() || newValue.IsNull() || newValue.IsUnknown() {
+		return false, diags
+	}
+
+	return strings.TrimSpace(v.ValueString()) == strings.TrimSpace(newValue.ValueString()), diags
+}

--- a/internal/pkg/terraform/numbers.go
+++ b/internal/pkg/terraform/numbers.go
@@ -1,0 +1,22 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Int64PtrIfKnown returns a pointer to the int64 value when it is set (known and
+// non-null), and nil when it is null or unknown.
+//
+// This lets request structs use `*int64` with `omitempty` so that:
+//   - an unset field (unknown/null) is omitted, letting the API apply its default
+//   - an explicit 0 is sent as 0, so callers can reset a value to zero
+//
+// Note: types.Int64.ValueInt64Pointer() cannot be used directly because it
+// returns a pointer to 0 (not nil) for unknown values.
+func Int64PtrIfKnown(v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	value := v.ValueInt64()
+	return &value
+}

--- a/internal/provider/resource/identity_aws_auth.go
+++ b/internal/provider/resource/identity_aws_auth.go
@@ -205,9 +205,9 @@ func (r *IdentityAwsAuthResource) Create(ctx context.Context, req resource.Creat
 
 	newIdentityAwsAuth, err := r.client.CreateIdentityAwsAuth(infisical.CreateIdentityAwsAuthRequest{
 		IdentityID:              plan.IdentityID.ValueString(),
-		AccessTokenTTL:          plan.AccessTokenTTL.ValueInt64(),
-		AccessTokenMaxTTL:       plan.AccessTokenMaxTTL.ValueInt64(),
-		AccessTokenNumUsesLimit: plan.AccessTokenNumUsesLimit.ValueInt64(),
+		AccessTokenTTL:          infisicaltf.Int64PtrIfKnown(plan.AccessTokenTTL),
+		AccessTokenMaxTTL:       infisicaltf.Int64PtrIfKnown(plan.AccessTokenMaxTTL),
+		AccessTokenNumUsesLimit: infisicaltf.Int64PtrIfKnown(plan.AccessTokenNumUsesLimit),
 		StsEndpoint:             plan.StsEndpoint.ValueString(),
 		AllowedAccountIDS:       strings.Join(allowedAccoundIds, ","),
 		AllowedPrincipalArns:    strings.Join(allowedPrincipalArns, ","),
@@ -308,9 +308,9 @@ func (r *IdentityAwsAuthResource) Update(ctx context.Context, req resource.Updat
 	updatedIdentityAwsAuth, err := r.client.UpdateIdentityAwsAuth(infisical.UpdateIdentityAwsAuthRequest{
 		IdentityID:              plan.IdentityID.ValueString(),
 		AccessTokenTrustedIPS:   accessTokenTrustedIps,
-		AccessTokenTTL:          plan.AccessTokenTTL.ValueInt64(),
-		AccessTokenMaxTTL:       plan.AccessTokenMaxTTL.ValueInt64(),
-		AccessTokenNumUsesLimit: plan.AccessTokenNumUsesLimit.ValueInt64(),
+		AccessTokenTTL:          infisicaltf.Int64PtrIfKnown(plan.AccessTokenTTL),
+		AccessTokenMaxTTL:       infisicaltf.Int64PtrIfKnown(plan.AccessTokenMaxTTL),
+		AccessTokenNumUsesLimit: infisicaltf.Int64PtrIfKnown(plan.AccessTokenNumUsesLimit),
 		StsEndpoint:             plan.StsEndpoint.ValueString(),
 		AllowedAccountIDS:       strings.Join(allowedAccoundIds, ","),
 		AllowedPrincipalArns:    strings.Join(allowedPrincipalArns, ","),

--- a/internal/provider/resource/identity_kubernetes_auth.go
+++ b/internal/provider/resource/identity_kubernetes_auth.go
@@ -252,7 +252,7 @@ func validateTokenReviewerMode(diagnose *diag.Diagnostics, plan *IdentityKuberne
 			return
 		}
 
-		if plan.CaCertificate.ValueString() != "" {
+		if strings.TrimSpace(plan.CaCertificate.ValueString()) != "" {
 			diagnose.AddError(
 				"Cannot set CA certificate",
 				"CA certificate is not allowed when token reviewer mode is gateway. Please remove the CA certificate.",
@@ -260,7 +260,7 @@ func validateTokenReviewerMode(diagnose *diag.Diagnostics, plan *IdentityKuberne
 			return
 		}
 
-		if plan.KubernetesHost.ValueString() != "" {
+		if strings.TrimSpace(plan.KubernetesHost.ValueString()) != "" {
 			diagnose.AddError(
 				"Cannot set Kubernetes host",
 				"Kubernetes host is not allowed when token reviewer mode is gateway. Please remove the Kubernetes host.",
@@ -268,7 +268,7 @@ func validateTokenReviewerMode(diagnose *diag.Diagnostics, plan *IdentityKuberne
 			return
 		}
 
-		if plan.TokenReviewerJWT.ValueString() != "" {
+		if strings.TrimSpace(plan.TokenReviewerJWT.ValueString()) != "" {
 			diagnose.AddError(
 				"Cannot set Token reviewer JWT",
 				"Token reviewer JWT is not allowed when token reviewer mode is gateway. Please remove the Token reviewer JWT.",
@@ -278,7 +278,7 @@ func validateTokenReviewerMode(diagnose *diag.Diagnostics, plan *IdentityKuberne
 	} else if tokenReviewerMode == TOKEN_REVIEWER_MODE_API {
 		// plan.TokenReviewerJWT is optional. if set to nothing, the auth method will act as self-reviewer.
 
-		if plan.KubernetesHost.ValueString() == "" {
+		if strings.TrimSpace(plan.KubernetesHost.ValueString()) == "" {
 			diagnose.AddError(
 				"Kubernetes host is required",
 				"Kubernetes host is required when token reviewer mode is api. Please provide a valid Kubernetes host.",

--- a/internal/provider/resource/identity_kubernetes_auth.go
+++ b/internal/provider/resource/identity_kubernetes_auth.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	infisical "terraform-provider-infisical/internal/client"
+	customtypes "terraform-provider-infisical/internal/pkg/customtypes"
 	infisicalstrings "terraform-provider-infisical/internal/pkg/strings"
 	infisicaltf "terraform-provider-infisical/internal/pkg/terraform"
 
@@ -34,18 +35,18 @@ type IdentityKubernetesAuthResource struct {
 
 // IdentityKubernetesAuthResourceSourceModel describes the data source data model.
 type IdentityKubernetesAuthResourceModel struct {
-	ID                         types.String `tfsdk:"id"`
-	IdentityID                 types.String `tfsdk:"identity_id"`
-	KubernetesHost             types.String `tfsdk:"kubernetes_host"`
-	CaCertificate              types.String `tfsdk:"kubernetes_ca_certificate"`
-	TokenReviewerJWT           types.String `tfsdk:"token_reviewer_jwt"`
-	AllowedServiceAccountNames types.List   `tfsdk:"allowed_service_account_names"`
-	AllowedAudience            types.String `tfsdk:"allowed_audience"`
-	AllowedNamespaces          types.List   `tfsdk:"allowed_namespaces"`
-	AccessTokenTTL             types.Int64  `tfsdk:"access_token_ttl"`
-	AccessTokenMaxTTL          types.Int64  `tfsdk:"access_token_max_ttl"`
-	AccessTokenNumUsesLimit    types.Int64  `tfsdk:"access_token_num_uses_limit"`
-	AccessTokenTrustedIps      types.List   `tfsdk:"access_token_trusted_ips"`
+	ID                         types.String                   `tfsdk:"id"`
+	IdentityID                 types.String                   `tfsdk:"identity_id"`
+	KubernetesHost             types.String                   `tfsdk:"kubernetes_host"`
+	CaCertificate              customtypes.TrimmedStringValue `tfsdk:"kubernetes_ca_certificate"`
+	TokenReviewerJWT           types.String                   `tfsdk:"token_reviewer_jwt"`
+	AllowedServiceAccountNames types.List                     `tfsdk:"allowed_service_account_names"`
+	AllowedAudience            types.String                   `tfsdk:"allowed_audience"`
+	AllowedNamespaces          types.List                     `tfsdk:"allowed_namespaces"`
+	AccessTokenTTL             types.Int64                    `tfsdk:"access_token_ttl"`
+	AccessTokenMaxTTL          types.Int64                    `tfsdk:"access_token_max_ttl"`
+	AccessTokenNumUsesLimit    types.Int64                    `tfsdk:"access_token_num_uses_limit"`
+	AccessTokenTrustedIps      types.List                     `tfsdk:"access_token_trusted_ips"`
 
 	GatewayID         types.String `tfsdk:"gateway_id"`
 	TokenReviewerMode types.String `tfsdk:"token_reviewer_mode"` // api|gateway (default is api)
@@ -105,6 +106,7 @@ func (r *IdentityKubernetesAuthResource) Schema(_ context.Context, _ resource.Sc
 			},
 
 			"kubernetes_ca_certificate": schema.StringAttribute{
+				CustomType:          customtypes.TrimmedStringType{},
 				Description:         "The PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server.",
 				MarkdownDescription: "The PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server.",
 				Optional:            true,
@@ -184,7 +186,7 @@ func updateKubernetesAuthStateByApi(ctx context.Context, diagnose diag.Diagnosti
 	plan.AccessTokenTTL = types.Int64Value(newIdentityKubernetesAuth.AccessTokenTTL)
 	plan.AccessTokenNumUsesLimit = types.Int64Value(newIdentityKubernetesAuth.AccessTokenNumUsesLimit)
 	plan.AllowedAudience = types.StringValue(newIdentityKubernetesAuth.AllowedAudience)
-	plan.CaCertificate = types.StringValue(newIdentityKubernetesAuth.CACERT)
+	plan.CaCertificate = customtypes.NewTrimmedStringValue(newIdentityKubernetesAuth.CACERT)
 	plan.TokenReviewerMode = types.StringValue(newIdentityKubernetesAuth.TokenReviewerMode)
 
 	if newIdentityKubernetesAuth.GatewayID != "" {


### PR DESCRIPTION
## Summary

- Adds `TrimmedStringType` with whitespace-trimmed semantic equality and applies it to `kubernetes_ca_certificate` on `infisical_identity_kubernetes_auth`, fixing perpetual diffs and "Provider produced inconsistent result after apply" when the API trims PEM values.
- Fixes AWS identity auth access token TTL handling: request fields are now `*int64` with `omitempty`, and a new `Int64PtrIfKnown` helper omits unset values so the API can apply defaults while still allowing explicit `0`.

## Test plan

- [ ] Apply `infisical_identity_kubernetes_auth` with a `kubernetes_ca_certificate` containing trailing whitespace; confirm no perpetual diff after apply.
- [ ] Create/update `infisical_identity_aws_auth` without setting access token TTL fields; confirm they are omitted from the API request and API defaults are preserved.
- [ ] Set access token TTL fields explicitly to `0` on AWS auth; confirm `0` is sent and applied.
- [ ] Re-run `terraform plan` on existing Kubernetes and AWS auth resources; confirm no unexpected changes.