### PR TITLE
fix:  crossplane build

### DIFF
--- a/internal/pkg/terraform/identity_roles.go
+++ b/internal/pkg/terraform/identity_roles.go
@@ -1,0 +1,150 @@
+package terraform
+
+import (
+	"fmt"
+	"sort"
+	infisical "terraform-provider-infisical/internal/client"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const TemporaryModeRelative = "relative"
+
+// IdentityRole describes a role assignment on a project identity.
+type IdentityRole struct {
+	ID                      types.String `tfsdk:"id"`
+	RoleSlug                types.String `tfsdk:"role_slug"`
+	CustomRoleID            types.String `tfsdk:"custom_role_id"`
+	IsTemporary             types.Bool   `tfsdk:"is_temporary"`
+	TemporaryMode           types.String `tfsdk:"temporary_mode"`
+	TemporaryRange          types.String `tfsdk:"temporary_range"`
+	TemporaryAccesStartTime types.String `tfsdk:"temporary_access_start_time"`
+	TemporaryAccessEndTime  types.String `tfsdk:"temporary_access_end_time"`
+}
+
+// OrderAPIRolesByPlan reorders API-returned roles to match the ordering specified in the Terraform plan.
+// The API may return roles in a non-deterministic order, but Terraform requires list elements to maintain
+// the same positional order as the plan to avoid "inconsistent result after apply" errors.
+func OrderAPIRolesByPlan(planRoles []IdentityRole, apiRoles []IdentityRole) []IdentityRole {
+	apiRoleMap := make(map[string]IdentityRole, len(apiRoles))
+	for _, role := range apiRoles {
+		apiRoleMap[role.RoleSlug.ValueString()] = role
+	}
+
+	ordered := make([]IdentityRole, 0, len(apiRoles))
+	matched := make(map[string]bool)
+
+	for _, planRole := range planRoles {
+		slug := planRole.RoleSlug.ValueString()
+		if apiRole, ok := apiRoleMap[slug]; ok && !matched[slug] {
+			ordered = append(ordered, apiRole)
+			matched[slug] = true
+		}
+	}
+
+	var remaining []IdentityRole
+	for _, apiRole := range apiRoles {
+		if !matched[apiRole.RoleSlug.ValueString()] {
+			remaining = append(remaining, apiRole)
+		}
+	}
+	sort.Slice(remaining, func(i, j int) bool {
+		return remaining[i].RoleSlug.ValueString() < remaining[j].RoleSlug.ValueString()
+	})
+	ordered = append(ordered, remaining...)
+
+	return ordered
+}
+
+// BuildIdentityRequestRoles converts the roles declared in a Terraform plan into the
+// API request representation. It applies the defaults used across the provider for temporary
+// roles (relative mode, 1h range) and validates the role list: at least one permanent role is
+// required, role slugs must be unique, temporary-only fields may not be set on permanent roles,
+// and temporary_access_start_time must be in canonical RFC3339 UTC form.
+func BuildIdentityRequestRoles(planRoles []IdentityRole) ([]infisical.CreateProjectIdentityRequestRoles, error) {
+	var roles []infisical.CreateProjectIdentityRequestRoles
+	var hasAtleastOnePermanentRole bool
+	seenSlugs := make(map[string]bool, len(planRoles))
+	for _, el := range planRoles {
+		slug := el.RoleSlug.ValueString()
+		if seenSlugs[slug] {
+			return nil, fmt.Errorf("duplicate role_slug %q: each role may only appear once", slug)
+		}
+		seenSlugs[slug] = true
+
+		isTemporary := el.IsTemporary.ValueBool()
+		temporaryMode := el.TemporaryMode.ValueString()
+		temporaryRange := el.TemporaryRange.ValueString()
+		temporaryAccesStartTime := time.Now().UTC()
+
+		if !isTemporary {
+			hasAtleastOnePermanentRole = true
+			if temporaryMode != "" || temporaryRange != "" || el.TemporaryAccesStartTime.ValueString() != "" {
+				return nil, fmt.Errorf("role %q is permanent (is_temporary = false) but sets temporary_mode/temporary_range/temporary_access_start_time; set is_temporary = true or remove those fields", slug)
+			}
+		}
+
+		if el.TemporaryAccesStartTime.ValueString() != "" {
+			raw := el.TemporaryAccesStartTime.ValueString()
+			parsed, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				return nil, fmt.Errorf("must provide valid ISO timestamp for field temporary_access_start_time %q, role %q", raw, slug)
+			}
+			if canonical := parsed.UTC().Format(time.RFC3339); canonical != raw {
+				return nil, fmt.Errorf("temporary_access_start_time %q for role %q must be in canonical RFC3339 UTC format (e.g. %q)", raw, slug, canonical)
+			}
+			temporaryAccesStartTime = parsed
+		}
+
+		if isTemporary && temporaryMode == "" {
+			temporaryMode = TemporaryModeRelative
+		}
+		if isTemporary && temporaryRange == "" {
+			temporaryRange = "1h"
+		}
+
+		roles = append(roles, infisical.CreateProjectIdentityRequestRoles{
+			Role:                     slug,
+			IsTemporary:              isTemporary,
+			TemporaryMode:            temporaryMode,
+			TemporaryRange:           temporaryRange,
+			TemporaryAccessStartTime: temporaryAccesStartTime,
+		})
+	}
+
+	if !hasAtleastOnePermanentRole {
+		return nil, fmt.Errorf("must have atleast one permanent role")
+	}
+
+	return roles, nil
+}
+
+// MapAPIRolesToIdentityModel converts API project member roles into the Terraform model
+// representation, resolving custom role slugs and nulling temporary-only fields for permanent roles.
+func MapAPIRolesToIdentityModel(apiRoles []infisical.ProjectMemberRole) []IdentityRole {
+	result := make([]IdentityRole, 0, len(apiRoles))
+	for _, el := range apiRoles {
+		val := IdentityRole{
+			ID:                      types.StringValue(el.ID),
+			RoleSlug:                types.StringValue(el.Role),
+			TemporaryAccessEndTime:  types.StringValue(el.TemporaryAccessEndTime.Format(time.RFC3339)),
+			TemporaryRange:          types.StringValue(el.TemporaryRange),
+			TemporaryMode:           types.StringValue(el.TemporaryMode),
+			CustomRoleID:            types.StringValue(el.CustomRoleId),
+			IsTemporary:             types.BoolValue(el.IsTemporary),
+			TemporaryAccesStartTime: types.StringValue(el.TemporaryAccessStartTime.Format(time.RFC3339)),
+		}
+		if el.CustomRoleSlug != "" {
+			val.RoleSlug = types.StringValue(el.CustomRoleSlug)
+		}
+		if !el.IsTemporary {
+			val.TemporaryMode = types.StringNull()
+			val.TemporaryRange = types.StringNull()
+			val.TemporaryAccesStartTime = types.StringNull()
+			val.TemporaryAccessEndTime = types.StringNull()
+		}
+		result = append(result, val)
+	}
+	return result
+}

--- a/internal/provider/resource/project_identity_resource.go
+++ b/internal/provider/resource/project_identity_resource.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 	infisical "terraform-provider-infisical/internal/client"
-	"time"
+	tfpkg "terraform-provider-infisical/internal/pkg/terraform"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -38,29 +38,18 @@ type ProjectIdentityResource struct {
 
 // projectResourceSourceModel describes the data source data model.
 type ProjectIdentityResourceModel struct {
-	ProjectID     types.String          `tfsdk:"project_id"`
-	IdentityID    types.String          `tfsdk:"identity_id"`
-	Identity      types.Object          `tfsdk:"identity"`
-	Roles         []ProjectIdentityRole `tfsdk:"roles"`
-	MembershipId  types.String          `tfsdk:"membership_id"`
-	AdoptExisting types.Bool            `tfsdk:"adopt_existing"`
+	ProjectID     types.String         `tfsdk:"project_id"`
+	IdentityID    types.String         `tfsdk:"identity_id"`
+	Identity      types.Object         `tfsdk:"identity"`
+	Roles         []tfpkg.IdentityRole `tfsdk:"roles"`
+	MembershipId  types.String         `tfsdk:"membership_id"`
+	AdoptExisting types.Bool           `tfsdk:"adopt_existing"`
 }
 
 type ProjectIdentityDetails struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	AuthMethods types.List   `tfsdk:"auth_methods"`
-}
-
-type ProjectIdentityRole struct {
-	ID                      types.String `tfsdk:"id"`
-	RoleSlug                types.String `tfsdk:"role_slug"`
-	CustomRoleID            types.String `tfsdk:"custom_role_id"`
-	IsTemporary             types.Bool   `tfsdk:"is_temporary"`
-	TemporaryMode           types.String `tfsdk:"temporary_mode"`
-	TemporaryRange          types.String `tfsdk:"temporary_range"`
-	TemporaryAccesStartTime types.String `tfsdk:"temporary_access_start_time"`
-	TemporaryAccessEndTime  types.String `tfsdk:"temporary_access_end_time"`
 }
 
 // Metadata returns the resource type name.
@@ -164,139 +153,6 @@ func (r *ProjectIdentityResource) Schema(_ context.Context, _ resource.SchemaReq
 	}
 }
 
-// orderAPIIdentityRolesByPlan reorders API-returned roles to match the ordering specified in the Terraform plan.
-// The API may return roles in a non-deterministic order, but Terraform requires list elements to maintain
-// the same positional order as the plan to avoid "inconsistent result after apply" errors.
-func orderAPIIdentityRolesByPlan(planRoles []ProjectIdentityRole, apiRoles []ProjectIdentityRole) []ProjectIdentityRole {
-	apiRoleMap := make(map[string]ProjectIdentityRole, len(apiRoles))
-	for _, role := range apiRoles {
-		apiRoleMap[role.RoleSlug.ValueString()] = role
-	}
-
-	ordered := make([]ProjectIdentityRole, 0, len(apiRoles))
-	matched := make(map[string]bool)
-
-	// First, add roles in the order they appear in the plan (deduplicating by slug)
-	for _, planRole := range planRoles {
-		slug := planRole.RoleSlug.ValueString()
-		if apiRole, ok := apiRoleMap[slug]; ok && !matched[slug] {
-			ordered = append(ordered, apiRole)
-			matched[slug] = true
-		}
-	}
-
-	// Then, append any remaining API roles not present in the plan (sorted for determinism)
-	var remaining []ProjectIdentityRole
-	for _, apiRole := range apiRoles {
-		if !matched[apiRole.RoleSlug.ValueString()] {
-			remaining = append(remaining, apiRole)
-		}
-	}
-	sort.Slice(remaining, func(i, j int) bool {
-		return remaining[i].RoleSlug.ValueString() < remaining[j].RoleSlug.ValueString()
-	})
-	ordered = append(ordered, remaining...)
-
-	return ordered
-}
-
-// buildProjectIdentityRequestRoles converts the roles declared in a Terraform plan into the
-// API request representation. It applies the defaults used across the provider for temporary
-// roles (relative mode, 1h range) and validates the role list: at least one permanent role is
-// required, role slugs must be unique, temporary-only fields may not be set on permanent roles,
-// and temporary_access_start_time must be in canonical RFC3339 UTC form.
-func buildProjectIdentityRequestRoles(planRoles []ProjectIdentityRole) ([]infisical.CreateProjectIdentityRequestRoles, error) {
-	var roles []infisical.CreateProjectIdentityRequestRoles
-	var hasAtleastOnePermanentRole bool
-	seenSlugs := make(map[string]bool, len(planRoles))
-	for _, el := range planRoles {
-		slug := el.RoleSlug.ValueString()
-		if seenSlugs[slug] {
-			return nil, fmt.Errorf("duplicate role_slug %q: each role may only appear once", slug)
-		}
-		seenSlugs[slug] = true
-
-		isTemporary := el.IsTemporary.ValueBool()
-		temporaryMode := el.TemporaryMode.ValueString()
-		temporaryRange := el.TemporaryRange.ValueString()
-		temporaryAccesStartTime := time.Now().UTC()
-
-		if !isTemporary {
-			hasAtleastOnePermanentRole = true
-			if temporaryMode != "" || temporaryRange != "" || el.TemporaryAccesStartTime.ValueString() != "" {
-				return nil, fmt.Errorf("role %q is permanent (is_temporary = false) but sets temporary_mode/temporary_range/temporary_access_start_time; set is_temporary = true or remove those fields", slug)
-			}
-		}
-
-		if el.TemporaryAccesStartTime.ValueString() != "" {
-			raw := el.TemporaryAccesStartTime.ValueString()
-			parsed, err := time.Parse(time.RFC3339, raw)
-			if err != nil {
-				return nil, fmt.Errorf("must provide valid ISO timestamp for field temporary_access_start_time %q, role %q", raw, slug)
-			}
-			// The value is stored back from the API in canonical UTC RFC3339 (…Z). Require that
-			// form on input so the planned value matches the applied value.
-			if canonical := parsed.UTC().Format(time.RFC3339); canonical != raw {
-				return nil, fmt.Errorf("temporary_access_start_time %q for role %q must be in canonical RFC3339 UTC format (e.g. %q)", raw, slug, canonical)
-			}
-			temporaryAccesStartTime = parsed
-		}
-
-		// default values
-		if isTemporary && temporaryMode == "" {
-			temporaryMode = TEMPORARY_MODE_RELATIVE
-		}
-		if isTemporary && temporaryRange == "" {
-			temporaryRange = "1h"
-		}
-
-		roles = append(roles, infisical.CreateProjectIdentityRequestRoles{
-			Role:                     slug,
-			IsTemporary:              isTemporary,
-			TemporaryMode:            temporaryMode,
-			TemporaryRange:           temporaryRange,
-			TemporaryAccessStartTime: temporaryAccesStartTime,
-		})
-	}
-
-	if !hasAtleastOnePermanentRole {
-		return nil, fmt.Errorf("must have atleast one permanent role")
-	}
-
-	return roles, nil
-}
-
-// mapAPIRolesToIdentityModel converts API project member roles into the Terraform model
-// representation, resolving custom role slugs and nulling temporary-only fields for permanent roles.
-func mapAPIRolesToIdentityModel(apiRoles []infisical.ProjectMemberRole) []ProjectIdentityRole {
-	result := make([]ProjectIdentityRole, 0, len(apiRoles))
-	for _, el := range apiRoles {
-		val := ProjectIdentityRole{
-			ID:                      types.StringValue(el.ID),
-			RoleSlug:                types.StringValue(el.Role),
-			TemporaryAccessEndTime:  types.StringValue(el.TemporaryAccessEndTime.Format(time.RFC3339)),
-			TemporaryRange:          types.StringValue(el.TemporaryRange),
-			TemporaryMode:           types.StringValue(el.TemporaryMode),
-			CustomRoleID:            types.StringValue(el.CustomRoleId),
-			IsTemporary:             types.BoolValue(el.IsTemporary),
-			TemporaryAccesStartTime: types.StringValue(el.TemporaryAccessStartTime.Format(time.RFC3339)),
-		}
-		// For a custom role the API returns role = "custom" and the real slug in
-		// customRoleSlug (v1 omits customRoleId entirely, v2 includes it).
-		if el.CustomRoleSlug != "" {
-			val.RoleSlug = types.StringValue(el.CustomRoleSlug)
-		}
-		if !el.IsTemporary {
-			val.TemporaryMode = types.StringNull()
-			val.TemporaryRange = types.StringNull()
-			val.TemporaryAccesStartTime = types.StringNull()
-			val.TemporaryAccessEndTime = types.StringNull()
-		}
-		result = append(result, val)
-	}
-	return result
-}
-
 // Configure adds the provider configured client to the resource.
 func (r *ProjectIdentityResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
@@ -335,7 +191,7 @@ func (r *ProjectIdentityResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	roles, err := buildProjectIdentityRequestRoles(plan.Roles)
+	roles, err := tfpkg.BuildIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -424,8 +280,8 @@ func (r *ProjectIdentityResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	apiRoles := mapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
-	plan.Roles = orderAPIIdentityRolesByPlan(plan.Roles, apiRoles)
+	apiRoles := tfpkg.MapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
+	plan.Roles = tfpkg.OrderAPIRolesByPlan(plan.Roles, apiRoles)
 	plan.MembershipId = types.StringValue(projectIdentityDetails.Membership.ID)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -487,8 +343,8 @@ func (r *ProjectIdentityResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	apiRoles := mapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
-	state.Roles = orderAPIIdentityRolesByPlan(state.Roles, apiRoles)
+	apiRoles := tfpkg.MapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
+	state.Roles = tfpkg.OrderAPIRolesByPlan(state.Roles, apiRoles)
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -542,7 +398,7 @@ func (r *ProjectIdentityResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	requestRoles, err := buildProjectIdentityRequestRoles(plan.Roles)
+	requestRoles, err := tfpkg.BuildIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -578,8 +434,8 @@ func (r *ProjectIdentityResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	apiRoles := mapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
-	plan.Roles = orderAPIIdentityRolesByPlan(plan.Roles, apiRoles)
+	apiRoles := tfpkg.MapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
+	plan.Roles = tfpkg.OrderAPIRolesByPlan(plan.Roles, apiRoles)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -652,7 +508,7 @@ func (r *ProjectIdentityResource) ImportState(ctx context.Context, req resource.
 	}
 	identityDetails.AuthMethods = types.ListValueMust(types.StringType, authMethods)
 
-	planRoles := mapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
+	planRoles := tfpkg.MapAPIRolesToIdentityModel(projectIdentityDetails.Membership.Roles)
 
 	// Sort roles alphabetically by slug for deterministic state after import
 	sort.Slice(planRoles, func(i, j int) bool {

--- a/internal/provider/resource/project_scoped_identity_resource.go
+++ b/internal/provider/resource/project_scoped_identity_resource.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 	infisical "terraform-provider-infisical/internal/client"
-	"time"
+	tfpkg "terraform-provider-infisical/internal/pkg/terraform"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -36,25 +36,13 @@ type ProjectScopedIdentityResource struct {
 
 // ProjectScopedIdentityResourceModel describes the resource data model.
 type ProjectScopedIdentityResourceModel struct {
-	ID                  types.String                `tfsdk:"id"`
-	ProjectID           types.String                `tfsdk:"project_id"`
-	Name                types.String                `tfsdk:"name"`
-	HasDeleteProtection types.Bool                  `tfsdk:"has_delete_protection"`
-	AuthMethods         types.List                  `tfsdk:"auth_methods"`
-	Metadata            []MetaEntry                 `tfsdk:"metadata"`
-	Roles               []ProjectScopedIdentityRole `tfsdk:"roles"`
-}
-
-// ProjectScopedIdentityRole describes a role of a Project Scoped Identity.
-type ProjectScopedIdentityRole struct {
-	ID                      types.String `tfsdk:"id"`
-	RoleSlug                types.String `tfsdk:"role_slug"`
-	CustomRoleID            types.String `tfsdk:"custom_role_id"`
-	IsTemporary             types.Bool   `tfsdk:"is_temporary"`
-	TemporaryMode           types.String `tfsdk:"temporary_mode"`
-	TemporaryRange          types.String `tfsdk:"temporary_range"`
-	TemporaryAccesStartTime types.String `tfsdk:"temporary_access_start_time"`
-	TemporaryAccessEndTime  types.String `tfsdk:"temporary_access_end_time"`
+	ID                  types.String         `tfsdk:"id"`
+	ProjectID           types.String         `tfsdk:"project_id"`
+	Name                types.String         `tfsdk:"name"`
+	HasDeleteProtection types.Bool           `tfsdk:"has_delete_protection"`
+	AuthMethods         types.List           `tfsdk:"auth_methods"`
+	Metadata            []MetaEntry          `tfsdk:"metadata"`
+	Roles               []tfpkg.IdentityRole `tfsdk:"roles"`
 }
 
 // Metadata returns the resource type name.
@@ -163,139 +151,6 @@ func (r *ProjectScopedIdentityResource) Schema(_ context.Context, _ resource.Sch
 	}
 }
 
-// orderAPIScopedIdentityRolesByPlan reorders API-returned roles to match the ordering specified in the Terraform plan.
-// The API may return roles in a non-deterministic order, but Terraform requires list elements to maintain
-// the same positional order as the plan to avoid "inconsistent result after apply" errors.
-func orderAPIScopedIdentityRolesByPlan(planRoles []ProjectScopedIdentityRole, apiRoles []ProjectScopedIdentityRole) []ProjectScopedIdentityRole {
-	apiRoleMap := make(map[string]ProjectScopedIdentityRole, len(apiRoles))
-	for _, role := range apiRoles {
-		apiRoleMap[role.RoleSlug.ValueString()] = role
-	}
-
-	ordered := make([]ProjectScopedIdentityRole, 0, len(apiRoles))
-	matched := make(map[string]bool)
-
-	// First, add roles in the order they appear in the plan (deduplicating by slug)
-	for _, planRole := range planRoles {
-		slug := planRole.RoleSlug.ValueString()
-		if apiRole, ok := apiRoleMap[slug]; ok && !matched[slug] {
-			ordered = append(ordered, apiRole)
-			matched[slug] = true
-		}
-	}
-
-	// Then, append any remaining API roles not present in the plan (sorted for determinism)
-	var remaining []ProjectScopedIdentityRole
-	for _, apiRole := range apiRoles {
-		if !matched[apiRole.RoleSlug.ValueString()] {
-			remaining = append(remaining, apiRole)
-		}
-	}
-	sort.Slice(remaining, func(i, j int) bool {
-		return remaining[i].RoleSlug.ValueString() < remaining[j].RoleSlug.ValueString()
-	})
-	ordered = append(ordered, remaining...)
-
-	return ordered
-}
-
-// buildProjectIdentityRequestRoles converts the roles declared in a Terraform plan into the
-// API request representation. It applies the defaults used across the provider for temporary
-// roles (relative mode, 1h range) and validates the role list: at least one permanent role is
-// required, role slugs must be unique, temporary-only fields may not be set on permanent roles,
-// and temporary_access_start_time must be in canonical RFC3339 UTC form.
-func buildProjectScopedIdentityRequestRoles(planRoles []ProjectScopedIdentityRole) ([]infisical.CreateProjectIdentityRequestRoles, error) {
-	var roles []infisical.CreateProjectIdentityRequestRoles
-	var hasAtleastOnePermanentRole bool
-	seenSlugs := make(map[string]bool, len(planRoles))
-	for _, el := range planRoles {
-		slug := el.RoleSlug.ValueString()
-		if seenSlugs[slug] {
-			return nil, fmt.Errorf("duplicate role_slug %q: each role may only appear once", slug)
-		}
-		seenSlugs[slug] = true
-
-		isTemporary := el.IsTemporary.ValueBool()
-		temporaryMode := el.TemporaryMode.ValueString()
-		temporaryRange := el.TemporaryRange.ValueString()
-		temporaryAccesStartTime := time.Now().UTC()
-
-		if !isTemporary {
-			hasAtleastOnePermanentRole = true
-			if temporaryMode != "" || temporaryRange != "" || el.TemporaryAccesStartTime.ValueString() != "" {
-				return nil, fmt.Errorf("role %q is permanent (is_temporary = false) but sets temporary_mode/temporary_range/temporary_access_start_time; set is_temporary = true or remove those fields", slug)
-			}
-		}
-
-		if el.TemporaryAccesStartTime.ValueString() != "" {
-			raw := el.TemporaryAccesStartTime.ValueString()
-			parsed, err := time.Parse(time.RFC3339, raw)
-			if err != nil {
-				return nil, fmt.Errorf("must provide valid ISO timestamp for field temporary_access_start_time %q, role %q", raw, slug)
-			}
-			// The value is stored back from the API in canonical UTC RFC3339 (…Z). Require that
-			// form on input so the planned value matches the applied value.
-			if canonical := parsed.UTC().Format(time.RFC3339); canonical != raw {
-				return nil, fmt.Errorf("temporary_access_start_time %q for role %q must be in canonical RFC3339 UTC format (e.g. %q)", raw, slug, canonical)
-			}
-			temporaryAccesStartTime = parsed
-		}
-
-		// default values
-		if isTemporary && temporaryMode == "" {
-			temporaryMode = TEMPORARY_MODE_RELATIVE
-		}
-		if isTemporary && temporaryRange == "" {
-			temporaryRange = "1h"
-		}
-
-		roles = append(roles, infisical.CreateProjectIdentityRequestRoles{
-			Role:                     slug,
-			IsTemporary:              isTemporary,
-			TemporaryMode:            temporaryMode,
-			TemporaryRange:           temporaryRange,
-			TemporaryAccessStartTime: temporaryAccesStartTime,
-		})
-	}
-
-	if !hasAtleastOnePermanentRole {
-		return nil, fmt.Errorf("must have atleast one permanent role")
-	}
-
-	return roles, nil
-}
-
-// mapAPIRolesToIdentityModel converts API project member roles into the Terraform model
-// representation, resolving custom role slugs and nulling temporary-only fields for permanent roles.
-func mapAPIRolesToScopedIdentityModel(apiRoles []infisical.ProjectMemberRole) []ProjectScopedIdentityRole {
-	result := make([]ProjectScopedIdentityRole, 0, len(apiRoles))
-	for _, el := range apiRoles {
-		val := ProjectScopedIdentityRole{
-			ID:                      types.StringValue(el.ID),
-			RoleSlug:                types.StringValue(el.Role),
-			TemporaryAccessEndTime:  types.StringValue(el.TemporaryAccessEndTime.Format(time.RFC3339)),
-			TemporaryRange:          types.StringValue(el.TemporaryRange),
-			TemporaryMode:           types.StringValue(el.TemporaryMode),
-			CustomRoleID:            types.StringValue(el.CustomRoleId),
-			IsTemporary:             types.BoolValue(el.IsTemporary),
-			TemporaryAccesStartTime: types.StringValue(el.TemporaryAccessStartTime.Format(time.RFC3339)),
-		}
-		// For a custom role the API returns role = "custom" and the real slug in
-		// customRoleSlug (v1 omits customRoleId entirely, v2 includes it).
-		if el.CustomRoleSlug != "" {
-			val.RoleSlug = types.StringValue(el.CustomRoleSlug)
-		}
-		if !el.IsTemporary {
-			val.TemporaryMode = types.StringNull()
-			val.TemporaryRange = types.StringNull()
-			val.TemporaryAccesStartTime = types.StringNull()
-			val.TemporaryAccessEndTime = types.StringNull()
-		}
-		result = append(result, val)
-	}
-	return result
-}
-
 // Configure adds the provider configured client to the resource.
 func (r *ProjectScopedIdentityResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
@@ -331,7 +186,7 @@ func (r *ProjectScopedIdentityResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	roles, err := buildProjectScopedIdentityRequestRoles(plan.Roles)
+	roles, err := tfpkg.BuildIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -374,7 +229,7 @@ func (r *ProjectScopedIdentityResource) Create(ctx context.Context, req resource
 	if plan.Metadata != nil {
 		plan.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	plan.Roles = orderAPIScopedIdentityRolesByPlan(plan.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
+	plan.Roles = tfpkg.OrderAPIRolesByPlan(plan.Roles, tfpkg.MapAPIRolesToIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -440,7 +295,7 @@ func (r *ProjectScopedIdentityResource) Read(ctx context.Context, req resource.R
 	if state.Metadata != nil {
 		state.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	state.Roles = orderAPIScopedIdentityRolesByPlan(state.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
+	state.Roles = tfpkg.OrderAPIRolesByPlan(state.Roles, tfpkg.MapAPIRolesToIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -470,7 +325,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	roles, err := buildProjectScopedIdentityRequestRoles(plan.Roles)
+	roles, err := tfpkg.BuildIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -506,7 +361,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 			ProjectID:  state.ProjectID.ValueString(),
 			IdentityID: state.ID.ValueString(),
 		}); readErr == nil {
-			plan.Roles = orderAPIScopedIdentityRolesByPlan(state.Roles, mapAPIRolesToScopedIdentityModel(current.Membership.Roles))
+			plan.Roles = tfpkg.OrderAPIRolesByPlan(state.Roles, tfpkg.MapAPIRolesToIdentityModel(current.Membership.Roles))
 		} else {
 			plan.Roles = state.Roles
 		}
@@ -536,7 +391,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 	if plan.Metadata != nil {
 		plan.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	plan.Roles = orderAPIScopedIdentityRolesByPlan(plan.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
+	plan.Roles = tfpkg.OrderAPIRolesByPlan(plan.Roles, tfpkg.MapAPIRolesToIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -636,7 +491,7 @@ func (r *ProjectScopedIdentityResource) ImportState(ctx context.Context, req res
 
 	// Sort roles by slug for a deterministic order on import (there is no plan to align
 	// against), matching the behaviour of the infisical_project_identity resource.
-	roles := mapAPIRolesToScopedIdentityModel(membership.Membership.Roles)
+	roles := tfpkg.MapAPIRolesToIdentityModel(membership.Membership.Roles)
 	sort.Slice(roles, func(i, j int) bool {
 		return roles[i].RoleSlug.ValueString() < roles[j].RoleSlug.ValueString()
 	})

--- a/internal/provider/resource/project_scoped_identity_resource.go
+++ b/internal/provider/resource/project_scoped_identity_resource.go
@@ -45,7 +45,7 @@ type ProjectScopedIdentityResourceModel struct {
 	Roles               []ProjectScopedIdentityRole `tfsdk:"roles"`
 }
 
-// ProjectScopedIdentityRole describes a role of a Project Scoped Identity
+// ProjectScopedIdentityRole describes a role of a Project Scoped Identity.
 type ProjectScopedIdentityRole struct {
 	ID                      types.String `tfsdk:"id"`
 	RoleSlug                types.String `tfsdk:"role_slug"`

--- a/internal/provider/resource/project_scoped_identity_resource.go
+++ b/internal/provider/resource/project_scoped_identity_resource.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	infisical "terraform-provider-infisical/internal/client"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -35,13 +36,25 @@ type ProjectScopedIdentityResource struct {
 
 // ProjectScopedIdentityResourceModel describes the resource data model.
 type ProjectScopedIdentityResourceModel struct {
-	ID                  types.String          `tfsdk:"id"`
-	ProjectID           types.String          `tfsdk:"project_id"`
-	Name                types.String          `tfsdk:"name"`
-	HasDeleteProtection types.Bool            `tfsdk:"has_delete_protection"`
-	AuthMethods         types.List            `tfsdk:"auth_methods"`
-	Metadata            []MetaEntry           `tfsdk:"metadata"`
-	Roles               []ProjectIdentityRole `tfsdk:"roles"`
+	ID                  types.String                `tfsdk:"id"`
+	ProjectID           types.String                `tfsdk:"project_id"`
+	Name                types.String                `tfsdk:"name"`
+	HasDeleteProtection types.Bool                  `tfsdk:"has_delete_protection"`
+	AuthMethods         types.List                  `tfsdk:"auth_methods"`
+	Metadata            []MetaEntry                 `tfsdk:"metadata"`
+	Roles               []ProjectScopedIdentityRole `tfsdk:"roles"`
+}
+
+// ProjectScopedIdentityRole describes a role of a Project Scoped Identity
+type ProjectScopedIdentityRole struct {
+	ID                      types.String `tfsdk:"id"`
+	RoleSlug                types.String `tfsdk:"role_slug"`
+	CustomRoleID            types.String `tfsdk:"custom_role_id"`
+	IsTemporary             types.Bool   `tfsdk:"is_temporary"`
+	TemporaryMode           types.String `tfsdk:"temporary_mode"`
+	TemporaryRange          types.String `tfsdk:"temporary_range"`
+	TemporaryAccesStartTime types.String `tfsdk:"temporary_access_start_time"`
+	TemporaryAccessEndTime  types.String `tfsdk:"temporary_access_end_time"`
 }
 
 // Metadata returns the resource type name.
@@ -150,6 +163,139 @@ func (r *ProjectScopedIdentityResource) Schema(_ context.Context, _ resource.Sch
 	}
 }
 
+// orderAPIScopedIdentityRolesByPlan reorders API-returned roles to match the ordering specified in the Terraform plan.
+// The API may return roles in a non-deterministic order, but Terraform requires list elements to maintain
+// the same positional order as the plan to avoid "inconsistent result after apply" errors.
+func orderAPIScopedIdentityRolesByPlan(planRoles []ProjectScopedIdentityRole, apiRoles []ProjectScopedIdentityRole) []ProjectScopedIdentityRole {
+	apiRoleMap := make(map[string]ProjectScopedIdentityRole, len(apiRoles))
+	for _, role := range apiRoles {
+		apiRoleMap[role.RoleSlug.ValueString()] = role
+	}
+
+	ordered := make([]ProjectScopedIdentityRole, 0, len(apiRoles))
+	matched := make(map[string]bool)
+
+	// First, add roles in the order they appear in the plan (deduplicating by slug)
+	for _, planRole := range planRoles {
+		slug := planRole.RoleSlug.ValueString()
+		if apiRole, ok := apiRoleMap[slug]; ok && !matched[slug] {
+			ordered = append(ordered, apiRole)
+			matched[slug] = true
+		}
+	}
+
+	// Then, append any remaining API roles not present in the plan (sorted for determinism)
+	var remaining []ProjectScopedIdentityRole
+	for _, apiRole := range apiRoles {
+		if !matched[apiRole.RoleSlug.ValueString()] {
+			remaining = append(remaining, apiRole)
+		}
+	}
+	sort.Slice(remaining, func(i, j int) bool {
+		return remaining[i].RoleSlug.ValueString() < remaining[j].RoleSlug.ValueString()
+	})
+	ordered = append(ordered, remaining...)
+
+	return ordered
+}
+
+// buildProjectIdentityRequestRoles converts the roles declared in a Terraform plan into the
+// API request representation. It applies the defaults used across the provider for temporary
+// roles (relative mode, 1h range) and validates the role list: at least one permanent role is
+// required, role slugs must be unique, temporary-only fields may not be set on permanent roles,
+// and temporary_access_start_time must be in canonical RFC3339 UTC form.
+func buildProjectScopedIdentityRequestRoles(planRoles []ProjectScopedIdentityRole) ([]infisical.CreateProjectIdentityRequestRoles, error) {
+	var roles []infisical.CreateProjectIdentityRequestRoles
+	var hasAtleastOnePermanentRole bool
+	seenSlugs := make(map[string]bool, len(planRoles))
+	for _, el := range planRoles {
+		slug := el.RoleSlug.ValueString()
+		if seenSlugs[slug] {
+			return nil, fmt.Errorf("duplicate role_slug %q: each role may only appear once", slug)
+		}
+		seenSlugs[slug] = true
+
+		isTemporary := el.IsTemporary.ValueBool()
+		temporaryMode := el.TemporaryMode.ValueString()
+		temporaryRange := el.TemporaryRange.ValueString()
+		temporaryAccesStartTime := time.Now().UTC()
+
+		if !isTemporary {
+			hasAtleastOnePermanentRole = true
+			if temporaryMode != "" || temporaryRange != "" || el.TemporaryAccesStartTime.ValueString() != "" {
+				return nil, fmt.Errorf("role %q is permanent (is_temporary = false) but sets temporary_mode/temporary_range/temporary_access_start_time; set is_temporary = true or remove those fields", slug)
+			}
+		}
+
+		if el.TemporaryAccesStartTime.ValueString() != "" {
+			raw := el.TemporaryAccesStartTime.ValueString()
+			parsed, err := time.Parse(time.RFC3339, raw)
+			if err != nil {
+				return nil, fmt.Errorf("must provide valid ISO timestamp for field temporary_access_start_time %q, role %q", raw, slug)
+			}
+			// The value is stored back from the API in canonical UTC RFC3339 (…Z). Require that
+			// form on input so the planned value matches the applied value.
+			if canonical := parsed.UTC().Format(time.RFC3339); canonical != raw {
+				return nil, fmt.Errorf("temporary_access_start_time %q for role %q must be in canonical RFC3339 UTC format (e.g. %q)", raw, slug, canonical)
+			}
+			temporaryAccesStartTime = parsed
+		}
+
+		// default values
+		if isTemporary && temporaryMode == "" {
+			temporaryMode = TEMPORARY_MODE_RELATIVE
+		}
+		if isTemporary && temporaryRange == "" {
+			temporaryRange = "1h"
+		}
+
+		roles = append(roles, infisical.CreateProjectIdentityRequestRoles{
+			Role:                     slug,
+			IsTemporary:              isTemporary,
+			TemporaryMode:            temporaryMode,
+			TemporaryRange:           temporaryRange,
+			TemporaryAccessStartTime: temporaryAccesStartTime,
+		})
+	}
+
+	if !hasAtleastOnePermanentRole {
+		return nil, fmt.Errorf("must have atleast one permanent role")
+	}
+
+	return roles, nil
+}
+
+// mapAPIRolesToIdentityModel converts API project member roles into the Terraform model
+// representation, resolving custom role slugs and nulling temporary-only fields for permanent roles.
+func mapAPIRolesToScopedIdentityModel(apiRoles []infisical.ProjectMemberRole) []ProjectScopedIdentityRole {
+	result := make([]ProjectScopedIdentityRole, 0, len(apiRoles))
+	for _, el := range apiRoles {
+		val := ProjectScopedIdentityRole{
+			ID:                      types.StringValue(el.ID),
+			RoleSlug:                types.StringValue(el.Role),
+			TemporaryAccessEndTime:  types.StringValue(el.TemporaryAccessEndTime.Format(time.RFC3339)),
+			TemporaryRange:          types.StringValue(el.TemporaryRange),
+			TemporaryMode:           types.StringValue(el.TemporaryMode),
+			CustomRoleID:            types.StringValue(el.CustomRoleId),
+			IsTemporary:             types.BoolValue(el.IsTemporary),
+			TemporaryAccesStartTime: types.StringValue(el.TemporaryAccessStartTime.Format(time.RFC3339)),
+		}
+		// For a custom role the API returns role = "custom" and the real slug in
+		// customRoleSlug (v1 omits customRoleId entirely, v2 includes it).
+		if el.CustomRoleSlug != "" {
+			val.RoleSlug = types.StringValue(el.CustomRoleSlug)
+		}
+		if !el.IsTemporary {
+			val.TemporaryMode = types.StringNull()
+			val.TemporaryRange = types.StringNull()
+			val.TemporaryAccesStartTime = types.StringNull()
+			val.TemporaryAccessEndTime = types.StringNull()
+		}
+		result = append(result, val)
+	}
+	return result
+}
+
 // Configure adds the provider configured client to the resource.
 func (r *ProjectScopedIdentityResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
@@ -185,7 +331,7 @@ func (r *ProjectScopedIdentityResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	roles, err := buildProjectIdentityRequestRoles(plan.Roles)
+	roles, err := buildProjectScopedIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -228,7 +374,7 @@ func (r *ProjectScopedIdentityResource) Create(ctx context.Context, req resource
 	if plan.Metadata != nil {
 		plan.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	plan.Roles = orderAPIIdentityRolesByPlan(plan.Roles, mapAPIRolesToIdentityModel(membership.Membership.Roles))
+	plan.Roles = orderAPIScopedIdentityRolesByPlan(plan.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -294,7 +440,7 @@ func (r *ProjectScopedIdentityResource) Read(ctx context.Context, req resource.R
 	if state.Metadata != nil {
 		state.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	state.Roles = orderAPIIdentityRolesByPlan(state.Roles, mapAPIRolesToIdentityModel(membership.Membership.Roles))
+	state.Roles = orderAPIScopedIdentityRolesByPlan(state.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -324,7 +470,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	roles, err := buildProjectIdentityRequestRoles(plan.Roles)
+	roles, err := buildProjectScopedIdentityRequestRoles(plan.Roles)
 	if err != nil {
 		resp.Diagnostics.AddError("Error assigning role to identity", err.Error())
 		return
@@ -360,7 +506,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 			ProjectID:  state.ProjectID.ValueString(),
 			IdentityID: state.ID.ValueString(),
 		}); readErr == nil {
-			plan.Roles = orderAPIIdentityRolesByPlan(state.Roles, mapAPIRolesToIdentityModel(current.Membership.Roles))
+			plan.Roles = orderAPIScopedIdentityRolesByPlan(state.Roles, mapAPIRolesToScopedIdentityModel(current.Membership.Roles))
 		} else {
 			plan.Roles = state.Roles
 		}
@@ -390,7 +536,7 @@ func (r *ProjectScopedIdentityResource) Update(ctx context.Context, req resource
 	if plan.Metadata != nil {
 		plan.Metadata = metadataFromAPI(identity.Metadata)
 	}
-	plan.Roles = orderAPIIdentityRolesByPlan(plan.Roles, mapAPIRolesToIdentityModel(membership.Membership.Roles))
+	plan.Roles = orderAPIScopedIdentityRolesByPlan(plan.Roles, mapAPIRolesToScopedIdentityModel(membership.Membership.Roles))
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -490,7 +636,7 @@ func (r *ProjectScopedIdentityResource) ImportState(ctx context.Context, req res
 
 	// Sort roles by slug for a deterministic order on import (there is no plan to align
 	// against), matching the behaviour of the infisical_project_identity resource.
-	roles := mapAPIRolesToIdentityModel(membership.Membership.Roles)
+	roles := mapAPIRolesToScopedIdentityModel(membership.Membership.Roles)
 	sort.Slice(roles, func(i, j int) bool {
 		return roles[i].RoleSlug.ValueString() < roles[j].RoleSlug.ValueString()
 	})

--- a/scripts/prepare-crossplane.sh
+++ b/scripts/prepare-crossplane.sh
@@ -48,6 +48,12 @@ if [ -d "$SOURCE_DIR/project_template_resource" ]; then
   cp -f "$SOURCE_DIR/project_template_resource/resource.tf" "$EXAMPLES_DIR/infisical_project_template/"
 fi
 
+if [ -d "$SOURCE_DIR/secret_approval_policy_resource" ]; then
+  echo "Replacing secret_approval_policy_resource"
+  cp -f "$SOURCE_DIR/secret_approval_policy_resource/secret_approval_policy_resource.go" "$DESTINATION_DIR/"
+  cp -f "$SOURCE_DIR/secret_approval_policy_resource/resource.tf" "$EXAMPLES_DIR/infisical_project_template/"
+fi
+
 
 for item in "$DESTINATION_DIR/secret_sync"/* "$SOURCE_DIR/secret_sync"/*/; do
   # Skip if doesn't exist

--- a/scripts/prepare-crossplane.sh
+++ b/scripts/prepare-crossplane.sh
@@ -51,7 +51,7 @@ fi
 if [ -d "$SOURCE_DIR/secret_approval_policy_resource" ]; then
   echo "Replacing secret_approval_policy_resource"
   cp -f "$SOURCE_DIR/secret_approval_policy_resource/secret_approval_policy_resource.go" "$DESTINATION_DIR/secret_approval_policy.go"
-  cp -f "$SOURCE_DIR/secret_approval_policy_resource/resource.tf" "$EXAMPLES_DIR/infisical_project_template/"
+  cp -f "$SOURCE_DIR/secret_approval_policy_resource/resource.tf" "$EXAMPLES_DIR/infisical_secret_approval_policy/"
 fi
 
 

--- a/scripts/prepare-crossplane.sh
+++ b/scripts/prepare-crossplane.sh
@@ -50,7 +50,7 @@ fi
 
 if [ -d "$SOURCE_DIR/secret_approval_policy_resource" ]; then
   echo "Replacing secret_approval_policy_resource"
-  cp -f "$SOURCE_DIR/secret_approval_policy_resource/secret_approval_policy_resource.go" "$DESTINATION_DIR/"
+  cp -f "$SOURCE_DIR/secret_approval_policy_resource/secret_approval_policy_resource.go" "$DESTINATION_DIR/secret_approval_policy.go"
   cp -f "$SOURCE_DIR/secret_approval_policy_resource/resource.tf" "$EXAMPLES_DIR/infisical_project_template/"
 fi
 


### PR DESCRIPTION
## Problem

`internal/provider/resource/project_scoped_identity_resource.go` was using shared functions from `internal/provider/resource/project_identity_resource.go`, however, that file is replaced by `scripts/prepare-crossplane.sh`, removing those functions and replacing a type that was being used.

This would cause go to fail to build due to those functions being missing. This duplicates the functions and the type renaming them to prevent conflicts.