### PR TITLE
Add option to keep private entries out of state

### DIFF
--- a/docs/resources/dynamic_secret_mongo_atlas.md
+++ b/docs/resources/dynamic_secret_mongo_atlas.md
@@ -93,13 +93,15 @@ resource "infisical_dynamic_secret_mongo_atlas" "mongo-atlas" {
 
 Required:
 
-- `admin_private_key` (String, Sensitive) Admin user private API key
 - `admin_public_key` (String) Admin user public API key
 - `group_id` (String) Unique 24-hexadecimal digit string that identifies your project. This is the same as the project ID.
 - `roles` (Attributes List) (see [below for nested schema](#nestedatt--configuration--roles))
 
 Optional:
 
+- `admin_private_key` (String, Sensitive) Admin user private API key. This value is stored in the Terraform state; use admin_private_key_wo to keep it out of state. Exactly one of admin_private_key or admin_private_key_wo must be set.
+- `admin_private_key_wo` (String, Sensitive) Admin user private API key (write-only). This value is never stored in the Terraform state and can accept ephemeral values. Because it is not stored, changes to it are not detected; increment admin_private_key_wo_version to push a new value. Requires Terraform 1.11+.
+- `admin_private_key_wo_version` (Number) The version of the admin_private_key_wo value. Increment this to trigger an update of the private key.
 - `scopes` (Attributes List) (see [below for nested schema](#nestedatt--configuration--scopes))
 
 <a id="nestedatt--configuration--roles"></a>

--- a/docs/resources/dynamic_secret_sql_database.md
+++ b/docs/resources/dynamic_secret_sql_database.md
@@ -109,7 +109,6 @@ Required:
 - `creation_statement` (String) The creation statement to use to create the dynamic secret lease.
 - `database` (String) The name of the database to use.
 - `host` (String) The host of the database server.
-- `password` (String, Sensitive) The password to use to connect to the database.
 - `port` (Number) The port of the database server.
 - `revocation_statement` (String) The revocation statement to use to revoke the dynamic secret lease.
 - `username` (String) The username to use to connect to the database.
@@ -118,7 +117,10 @@ Optional:
 
 - `ca` (String) The CA certificate to use to connect to the database.
 - `gateway_id` (String) The Gateway ID to use to connect to the database.
+- `password` (String, Sensitive) The password to use to connect to the database. This value is stored in the Terraform state; use password_wo to keep it out of state. Exactly one of password or password_wo must be set.
 - `password_requirements` (Attributes) The password requirements to use to create the dynamic secret lease. (see [below for nested schema](#nestedatt--configuration--password_requirements))
+- `password_wo` (String, Sensitive) The password to use to connect to the database (write-only). This value is never stored in the Terraform state and can accept ephemeral values. Because it is not stored, changes to it are not detected; increment password_wo_version to push a new value. Requires Terraform 1.11+.
+- `password_wo_version` (Number) The version of the password_wo value. Increment this to trigger an update of the password.
 - `renew_statement` (String) The renew statement to use to renew the dynamic secret lease.
 
 <a id="nestedatt--configuration--password_requirements"></a>

--- a/internal/provider/resource/dynamic_secret/base_dynamic_secret.go
+++ b/internal/provider/resource/dynamic_secret/base_dynamic_secret.go
@@ -25,7 +25,7 @@ type DynamicSecretBaseResource struct {
 	DynamicSecretName         string // complete descriptive name of the dynamic secret
 	client                    *infisical.Client
 	ConfigurationAttributes   map[string]schema.Attribute
-	ReadConfigurationFromPlan func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics)
+	ReadConfigurationFromPlan func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics)
 	ReadConfigurationFromApi  func(ctx context.Context, dynamicSecret infisical.DynamicSecret, configState types.Object) (types.Object, diag.Diagnostics)
 }
 
@@ -150,7 +150,14 @@ func (r *DynamicSecretBaseResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	configurationMap, diags := r.ReadConfigurationFromPlan(ctx, plan)
+	var config DynamicSecretBaseResourceModel
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	configurationMap, diags := r.ReadConfigurationFromPlan(ctx, plan, config)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -306,7 +313,14 @@ func (r *DynamicSecretBaseResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	configurationMap, diags := r.ReadConfigurationFromPlan(ctx, plan)
+	var config DynamicSecretBaseResourceModel
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	configurationMap, diags := r.ReadConfigurationFromPlan(ctx, plan, config)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/resource/dynamic_secret/dynamic_secret_aws_iam.go
+++ b/internal/provider/resource/dynamic_secret/dynamic_secret_aws_iam.go
@@ -99,7 +99,7 @@ func NewDynamicSecretAwsIamResource() resource.Resource {
 			},
 		},
 
-		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
+		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
 			configurationMap := make(map[string]interface{})
 			var configuration DynamicSecretAwsIamConfigurationModel
 

--- a/internal/provider/resource/dynamic_secret/dynamic_secret_kubernetes.go
+++ b/internal/provider/resource/dynamic_secret/dynamic_secret_kubernetes.go
@@ -128,7 +128,7 @@ func NewDynamicSecretKubernetesResource() resource.Resource {
 			},
 		},
 
-		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
+		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
 			configurationMap := make(map[string]interface{})
 			var configuration DynamicSecretKubernetesConfigurationModel
 

--- a/internal/provider/resource/dynamic_secret/dynamic_secret_mongo_atlas.go
+++ b/internal/provider/resource/dynamic_secret/dynamic_secret_mongo_atlas.go
@@ -5,10 +5,14 @@ import (
 	"strconv"
 	infisical "terraform-provider-infisical/internal/client"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -25,11 +29,13 @@ type DynamicSecretMongoAtlasScopePlanModel struct {
 }
 
 type DynamicSecretMongoAtlasConfigurationModel struct {
-	AdminPublicKey  types.String `tfsdk:"admin_public_key"`
-	AdminPrivateKey types.String `tfsdk:"admin_private_key"`
-	GroupId         types.String `tfsdk:"group_id"`
-	Roles           types.List   `tfsdk:"roles"`
-	Scopes          types.List   `tfsdk:"scopes"`
+	AdminPublicKey           types.String `tfsdk:"admin_public_key"`
+	AdminPrivateKey          types.String `tfsdk:"admin_private_key"`
+	AdminPrivateKeyWO        types.String `tfsdk:"admin_private_key_wo"`
+	AdminPrivateKeyWOVersion types.Int64  `tfsdk:"admin_private_key_wo_version"`
+	GroupId                  types.String `tfsdk:"group_id"`
+	Roles                    types.List   `tfsdk:"roles"`
+	Scopes                   types.List   `tfsdk:"scopes"`
 }
 
 func NewDynamicSecretMongoAtlasResource() resource.Resource {
@@ -43,9 +49,35 @@ func NewDynamicSecretMongoAtlasResource() resource.Resource {
 				Description: "Admin user public API key",
 			},
 			"admin_private_key": schema.StringAttribute{
-				Required:    true,
-				Description: "Admin user private API key",
+				Optional:    true,
+				Description: "Admin user private API key. This value is stored in the Terraform state; use admin_private_key_wo to keep it out of state. Exactly one of admin_private_key or admin_private_key_wo must be set.",
 				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(
+						path.MatchRelative().AtParent().AtName("admin_private_key_wo"),
+					),
+				},
+			},
+			"admin_private_key_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "Admin user private API key (write-only). This value is never stored in the Terraform state and can accept ephemeral values. Because it is not stored, changes to it are not detected; increment admin_private_key_wo_version to push a new value. Requires Terraform 1.11+.",
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("admin_private_key_wo_version"),
+					),
+				},
+			},
+			"admin_private_key_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "The version of the admin_private_key_wo value. Increment this to trigger an update of the private key.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+					int64validator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("admin_private_key_wo"),
+					),
+				},
 			},
 			"group_id": schema.StringAttribute{
 				Required:    true,
@@ -88,7 +120,7 @@ func NewDynamicSecretMongoAtlasResource() resource.Resource {
 			},
 		},
 
-		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]any, diag.Diagnostics) {
+		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]any, diag.Diagnostics) {
 			configurationMap := make(map[string]any)
 			var configuration DynamicSecretMongoAtlasConfigurationModel
 
@@ -97,8 +129,20 @@ func NewDynamicSecretMongoAtlasResource() resource.Resource {
 				return nil, diags
 			}
 
+			// Write-only values are stripped from the plan, so read them from config
+			var rawConfiguration DynamicSecretMongoAtlasConfigurationModel
+			diags.Append(config.Configuration.As(ctx, &rawConfiguration, basetypes.ObjectAsOptions{})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			adminPrivateKey := configuration.AdminPrivateKey.ValueString()
+			if !rawConfiguration.AdminPrivateKeyWO.IsNull() {
+				adminPrivateKey = rawConfiguration.AdminPrivateKeyWO.ValueString()
+			}
+
 			configurationMap["adminPublicKey"] = configuration.AdminPublicKey.ValueString()
-			configurationMap["adminPrivateKey"] = configuration.AdminPrivateKey.ValueString()
+			configurationMap["adminPrivateKey"] = adminPrivateKey
 			configurationMap["groupId"] = configuration.GroupId.ValueString()
 
 			if !configuration.Roles.IsNull() && !configuration.Roles.IsUnknown() {
@@ -178,10 +222,20 @@ func NewDynamicSecretMongoAtlasResource() resource.Resource {
 				return types.ObjectNull(configState.AttributeTypes(ctx)), diags
 			}
 
+			// When admin_private_key_wo is used, admin_private_key is null in
+			// plan/state and must stay null so the API's value is never written
+			// to the state.
+			adminPrivateKeyValue := types.StringNull()
+			if !currentState.AdminPrivateKey.IsNull() {
+				adminPrivateKeyValue = types.StringValue(adminPrivateKey)
+			}
+
 			configuration := map[string]attr.Value{
-				"admin_public_key":  types.StringValue(adminPublicKey),
-				"admin_private_key": types.StringValue(adminPrivateKey),
-				"group_id":          types.StringValue(groupId),
+				"admin_public_key":             types.StringValue(adminPublicKey),
+				"admin_private_key":            adminPrivateKeyValue,
+				"admin_private_key_wo":         types.StringNull(),
+				"admin_private_key_wo_version": currentState.AdminPrivateKeyWOVersion,
+				"group_id":                     types.StringValue(groupId),
 			}
 
 			rolesRaw, ok := dynamicSecret.Inputs["roles"].([]any)
@@ -328,9 +382,11 @@ func NewDynamicSecretMongoAtlasResource() resource.Resource {
 			}
 
 			configType := map[string]attr.Type{
-				"admin_public_key":  types.StringType,
-				"admin_private_key": types.StringType,
-				"group_id":          types.StringType,
+				"admin_public_key":             types.StringType,
+				"admin_private_key":            types.StringType,
+				"admin_private_key_wo":         types.StringType,
+				"admin_private_key_wo_version": types.Int64Type,
+				"group_id":                     types.StringType,
 				"roles": types.ListType{
 					ElemType: types.ObjectType{
 						AttrTypes: map[string]attr.Type{

--- a/internal/provider/resource/dynamic_secret/dynamic_secret_mongo_db.go
+++ b/internal/provider/resource/dynamic_secret/dynamic_secret_mongo_db.go
@@ -60,7 +60,7 @@ func NewDynamicSecretMongoDbResource() resource.Resource {
 			},
 		},
 
-		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]any, diag.Diagnostics) {
+		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]any, diag.Diagnostics) {
 			configurationMap := make(map[string]any)
 			var configuration DynamicSecretMongoDbConfigurationModel
 

--- a/internal/provider/resource/dynamic_secret/dynamic_secret_sql_database.go
+++ b/internal/provider/resource/dynamic_secret/dynamic_secret_sql_database.go
@@ -6,11 +6,15 @@ import (
 	pkg "terraform-provider-infisical/internal/pkg/modifiers"
 	infisicaltf "terraform-provider-infisical/internal/pkg/terraform"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -36,6 +40,8 @@ type DynamicSecretSqlDatabaseConfigurationModel struct {
 	Database             types.String               `tfsdk:"database"`
 	Username             types.String               `tfsdk:"username"`
 	Password             types.String               `tfsdk:"password"`
+	PasswordWO           types.String               `tfsdk:"password_wo"`
+	PasswordWOVersion    types.Int64                `tfsdk:"password_wo_version"`
 	CreationStatement    types.String               `tfsdk:"creation_statement"`
 	RevocationStatement  types.String               `tfsdk:"revocation_statement"`
 	RenewStatement       types.String               `tfsdk:"renew_statement"`
@@ -71,9 +77,35 @@ func NewDynamicSecretSqlDatabaseResource() resource.Resource {
 				Description: "The username to use to connect to the database.",
 			},
 			"password": schema.StringAttribute{
-				Required:    true,
-				Description: "The password to use to connect to the database.",
+				Optional:    true,
+				Description: "The password to use to connect to the database. This value is stored in the Terraform state; use password_wo to keep it out of state. Exactly one of password or password_wo must be set.",
 				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(
+						path.MatchRelative().AtParent().AtName("password_wo"),
+					),
+				},
+			},
+			"password_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "The password to use to connect to the database (write-only). This value is never stored in the Terraform state and can accept ephemeral values. Because it is not stored, changes to it are not detected; increment password_wo_version to push a new value. Requires Terraform 1.11+.",
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("password_wo_version"),
+					),
+				},
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "The version of the password_wo value. Increment this to trigger an update of the password.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1),
+					int64validator.AlsoRequires(
+						path.MatchRelative().AtParent().AtName("password_wo"),
+					),
+				},
 			},
 			"creation_statement": schema.StringAttribute{
 				Required:    true,
@@ -142,7 +174,7 @@ func NewDynamicSecretSqlDatabaseResource() resource.Resource {
 			},
 		},
 
-		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
+		ReadConfigurationFromPlan: func(ctx context.Context, plan DynamicSecretBaseResourceModel, config DynamicSecretBaseResourceModel) (map[string]interface{}, diag.Diagnostics) {
 			configurationMap := make(map[string]interface{})
 			var configuration DynamicSecretSqlDatabaseConfigurationModel
 
@@ -151,12 +183,24 @@ func NewDynamicSecretSqlDatabaseResource() resource.Resource {
 				return nil, diags
 			}
 
+			// Write-only values are stripped from the plan, so read them from config
+			var rawConfiguration DynamicSecretSqlDatabaseConfigurationModel
+			diags.Append(config.Configuration.As(ctx, &rawConfiguration, basetypes.ObjectAsOptions{})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			password := configuration.Password.ValueString()
+			if !rawConfiguration.PasswordWO.IsNull() {
+				password = rawConfiguration.PasswordWO.ValueString()
+			}
+
 			configurationMap["client"] = configuration.Client.ValueString()
 			configurationMap["host"] = configuration.Host.ValueString()
 			configurationMap["port"] = configuration.Port.ValueInt64()
 			configurationMap["database"] = configuration.Database.ValueString()
 			configurationMap["username"] = configuration.Username.ValueString()
-			configurationMap["password"] = configuration.Password.ValueString()
+			configurationMap["password"] = password
 			configurationMap["creationStatement"] = configuration.CreationStatement.ValueString()
 			configurationMap["revocationStatement"] = configuration.RevocationStatement.ValueString()
 			configurationMap["renewStatement"] = configuration.RenewStatement.ValueString()
@@ -302,13 +346,22 @@ func NewDynamicSecretSqlDatabaseResource() resource.Resource {
 				renewStatementValue = types.StringValue(renewStatementFinal)
 			}
 
+			// When password_wo is used, password is null in plan/state and must
+			// stay null so the API's value is never written to the state.
+			passwordValue := types.StringNull()
+			if !existingConfig.Password.IsNull() {
+				passwordValue = types.StringValue(passwordVal)
+			}
+
 			configuration := map[string]attr.Value{
 				"client":               types.StringValue(clientVal),
 				"host":                 types.StringValue(hostVal),
 				"port":                 types.Int64Value(portVal),
 				"database":             types.StringValue(databaseVal),
 				"username":             types.StringValue(usernameVal),
-				"password":             types.StringValue(passwordVal),
+				"password":             passwordValue,
+				"password_wo":          types.StringNull(),
+				"password_wo_version":  existingConfig.PasswordWOVersion,
 				"creation_statement":   types.StringValue(creationStatementFinal),
 				"revocation_statement": types.StringValue(revocationStatementFinal),
 				"renew_statement":      renewStatementValue,
@@ -390,6 +443,8 @@ func NewDynamicSecretSqlDatabaseResource() resource.Resource {
 				"database":             types.StringType,
 				"username":             types.StringType,
 				"password":             types.StringType,
+				"password_wo":          types.StringType,
+				"password_wo_version":  types.Int64Type,
 				"creation_statement":   types.StringType,
 				"revocation_statement": types.StringType,
 				"renew_statement":      types.StringType,


### PR DESCRIPTION
Currently entries for secret items like DB Passwords, Mongo Atlas API Keys, and others don't support write only operations and are stored directly in state. These changes allow an option write only (wo) version of the secret fields. 

This supports:
- Keeping secrets out of state
- The use of ephemeral sources for secret values.